### PR TITLE
Add json_load_callback()

### DIFF
--- a/src/jansson.h
+++ b/src/jansson.h
@@ -232,10 +232,13 @@ json_t *json_deep_copy(json_t *value);
 #define JSON_DISABLE_EOF_CHECK 0x2
 #define JSON_DECODE_ANY        0x4
 
+typedef int (*json_load_callback_t)(void *);
+
 json_t *json_loads(const char *input, size_t flags, json_error_t *error);
 json_t *json_loadb(const char *buffer, size_t buflen, size_t flags, json_error_t *error);
 json_t *json_loadf(FILE *input, size_t flags, json_error_t *error);
 json_t *json_load_file(const char *path, size_t flags, json_error_t *error);
+json_t *json_load_callback(json_load_callback_t callback, void *data, size_t flags, json_error_t *error);
 
 
 /* encoding */

--- a/src/load.c
+++ b/src/load.c
@@ -990,3 +990,24 @@ json_t *json_load_file(const char *path, size_t flags, json_error_t *error)
     fclose(fp);
     return result;
 }
+
+json_t *json_load_callback(json_load_callback_t callback, void *data, size_t flags, json_error_t *error)
+{
+    lex_t lex;
+    json_t *result;
+
+    jsonp_error_init(error, "<callback>");
+
+    if (callback == NULL) {
+        error_set(error, NULL, "wrong arguments");
+        return NULL;
+    }
+
+    if(lex_init(&lex, (get_func)callback, data))
+        return NULL;
+
+    result = parse_json(&lex, flags, error);
+
+    lex_close(&lex);
+    return result;
+}

--- a/test/suites/api/Makefile.am
+++ b/test/suites/api/Makefile.am
@@ -8,6 +8,7 @@ check_PROGRAMS = \
 	test_equal \
 	test_load \
 	test_loadb \
+	test_load_callback \
 	test_memory_funcs \
 	test_number \
 	test_object \

--- a/test/suites/api/test_load_callback.c
+++ b/test/suites/api/test_load_callback.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2009-2011 Petri Lehtinen <petri@digip.org>
+ *
+ * Jansson is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ */
+
+#include <jansson.h>
+#include <string.h>
+#include <stdlib.h>
+#include "util.h"
+
+struct my_source {
+    const char *buf;
+    size_t off;
+    size_t cap;
+};
+
+static const char my_str[] = "[\"A\", {\"B\": \"C\", \"e\": false}, 1, null, \"foo\"]";
+
+static int my_reader(void *data)
+{
+    struct my_source *s = data;
+	if (s->off < s->cap)
+		return s->buf[s->off++];
+	else
+		return EOF;
+}
+
+static void run_tests()
+{
+    struct my_source s;
+    json_t *json;
+	json_error_t error;
+
+    s.off = 0;
+    s.cap = strlen(my_str);
+    s.buf = my_str;
+
+	json = json_load_callback(my_reader, &s, 0, &error);
+
+	if (!json)
+		fail("json_load_callback failed on a valid callback");
+	json_decref(json);
+
+	s.off = 0;
+	s.cap = strlen(my_str) - 1;
+	s.buf = my_str;
+
+	json = json_load_callback(my_reader, &s, 0, &error);
+	if (json) {
+	    json_decref(json);
+		fail("json_load_callback should have failed on an incomplete stream, but it didn't");
+	}
+	if (strcmp(error.source, "<callback>") != 0) {
+		fail("json_load_callback returned an invalid error source");
+	}
+    if (strcmp(error.text, "']' expected near end of file") != 0) {
+        fail("json_load_callback returned an invalid error message for an unclosed top-level array");
+    }
+
+	json = json_load_callback(NULL, NULL, 0, &error);
+	if (json) {
+		json_decref(json);
+		fail("json_load_callback should have failed on NULL load callback, but it didn't");
+	}
+	if (strcmp(error.text, "wrong arguments") != 0) {
+		fail("json_load_callback returned an invalid error message for a NULL load callback");
+	}
+}


### PR DESCRIPTION
Some embedded operation system only provide direct interface for file I/O, i.e. not supporting the native fopen()/fread() API. So I have to create a json_load_callback() wrapping to allow flexible input.

As we've already have a json_dump_callback(), it might be interesting for jansson to have one for loading too.
