### PR TITLE
Ignore the binary test_load_callback

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -14,3 +14,4 @@ suites/api/test_object
 suites/api/test_pack
 suites/api/test_simple
 suites/api/test_unpack
+suites/api/test_load_callback


### PR DESCRIPTION
Untracked files found after making check under Linux. I guess we should ignore it.
