### PR TITLE
Comment support

### DIFF
--- a/src/jansson.h
+++ b/src/jansson.h
@@ -231,6 +231,7 @@ json_t *json_deep_copy(json_t *value);
 #define JSON_REJECT_DUPLICATES 0x1
 #define JSON_DISABLE_EOF_CHECK 0x2
 #define JSON_DECODE_ANY        0x4
+#define JSON_COMMENTS_ALLOWED  0x8
 
 typedef size_t (*json_load_callback_t)(void *buffer, size_t buflen, void *data);
 

--- a/test/suites/api/test_load.c
+++ b/test/suites/api/test_load.c
@@ -139,7 +139,7 @@ static void comments()
     json_t *json;
     json_error_t error;
 
-    json = json_loads(text, 0, &error);
+    json = json_loads(text, JSON_COMMENTS_ALLOWED, &error);
     if(!json)
         fail("json_load comments failed");
     json_decref(json);


### PR DESCRIPTION
Hi, I needed support for comments, since I use your library for configs as well (similar as Sublime Text 2).
Looks like RFC 4627 hasn't such requirement, but it would be nice to support it.
