### PR TITLE
fix check-exports test on ppc64

### DIFF
--- a/test/suites/api/check-exports
+++ b/test/suites/api/check-exports
@@ -15,7 +15,7 @@ grep 'json_' $top_srcdir/src/jansson.def \
 nm -D $SOFILE >/dev/null >$test_log/symbols 2>/dev/null \
     || exit 77  # Skip if "nm -D" doesn't seem to work
 
-grep ' T ' $test_log/symbols | cut -d' ' -f3 | sort >$test_log/output
+grep ' [DT] ' $test_log/symbols | cut -d' ' -f3 | sort >$test_log/output
 
 if ! cmp -s $test_log/exports $test_log/output; then
     diff -u $test_log/exports $test_log/output >&2


### PR DESCRIPTION
This patch  fixes a test failure on 64-bit PowerPC. See [Debian bug #684468](http://bugs.debian.org/684468) for more information.
