### PR TITLE
Add -no-undefined to LDFLAGS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,6 +14,7 @@ libjansson_la_SOURCES = \
 	util.h \
 	value.c
 libjansson_la_LDFLAGS = \
+	-no-undefined \
 	-export-symbols-regex '^json_' \
 	-version-info 1:1:1
 


### PR DESCRIPTION
This tells libtool that jansson does not require any external symbols, and allows building it as a shared library (DLL) on Windows.
