### PR TITLE
added json_get() function, to parse JavaScript-stype identifiers

### DIFF
--- a/src/jansson.h
+++ b/src/jansson.h
@@ -124,6 +124,8 @@ typedef struct {
 
 /* getters, setters, manipulation */
 
+json_t *json_get(json_t *root, const char *path);
+
 size_t json_object_size(const json_t *object);
 json_t *json_object_get(const json_t *object, const char *key);
 int json_object_set_new(json_t *object, const char *key, json_t *value);


### PR DESCRIPTION
is as described. returns a 'borrowed' reference, perhaps you would prefer two variants - one to return a borrowed, the other to acquire a new reference.

If you like the function / want to include it, I would be happy to add to the documentation.
