### PR TITLE
Adjust CMakeLists.txt and .def: add _d postfix onto jansson_d.lib/dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,14 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 
+# Give the debug version a different postfix for windows,
+# so both the debug and release version can be built in the
+# same build-tree on Windows (MSVC).
+IF (WIN32)
+   SET (CMAKE_DEBUG_POSTFIX "_d")
+ELSE (WIN32)
+ENDIF (WIN32)
+
 # This is how I thought it should go
 # set (JANSSON_VERSION "2.3.1")
 # set (JANSSON_SOVERSION 2)

--- a/src/jansson.def
+++ b/src/jansson.def
@@ -1,5 +1,3 @@
-LIBRARY "jansson"
-
 EXPORTS
     json_delete
     json_true


### PR DESCRIPTION
Had to remove the "LIBRARY" line from jansson.def, which was optional,
and was overriding CMake's desire for a specific name.
