### PR TITLE
BUGFIX: Compilation error with -DNDEBUG defined.

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -253,9 +253,18 @@ static void lex_unget(lex_t *lex, int c)
 static void lex_unget_unsave(lex_t *lex, int c)
 {
     if(c != STREAM_STATE_EOF && c != STREAM_STATE_ERROR) {
+        /* Since we treat warnings as errors, when assertions are turned
+         * off the "d" variable would be set but never used. Which is
+         * treated as an error by GCC.
+         */
+        #ifndef NDEBUG
         char d;
+        #endif
         stream_unget(&lex->stream, c);
-        d = strbuffer_pop(&lex->saved_text);
+        #ifndef NDEBUG
+        d = 
+        #endif
+            strbuffer_pop(&lex->saved_text);
         assert(c == d);
     }
 }


### PR DESCRIPTION
When building a "MinSizeRel" with CMake I get a compilation error in lex_unget_unsave. This is because assertions are turned off using -DNDEBUG:

```
/usr/bin/gcc  -DHAVE_CONFIG_H -fPIC -Os -DNDEBUG -Ijansson/build/include -Ijansson/build/private_include    -Wall -Wextra -Wdeclaration-after-statement -Werror -o CMakeFiles/jansson.dir/src/load.c.o   -c jansson/src/load.c
jansson/src/load.c: In function âx_unget_unsaveâjansson/src/load.c:256:14: error: variable â set but not used [-Werror=unused-but-set-variable]
cc1: all warnings being treated as errors
```

This will then remove the insert, which makes the "d" variable unused, which is treated as an error since we have -Wall set. We can't simply get rid of the variable either and put the strbuffer_pop call in the assert call, since it's a macro and would remove the call entirely. So I simply added a check for NDEBUG to fix it.
