### PR TITLE
Cmake isnan isinf checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,8 @@ include (CheckFunctionExists)
 include (CheckFunctionKeywords)
 include (CheckIncludeFiles)
 include (CheckTypeSize)
+include (CheckLibraryExists)
+include (CheckCSourceCompiles)
 
 
 if (MSVC)
@@ -237,6 +239,38 @@ if (HAVE_SNPRINTF)
 elseif (HAVE__SNPRINTF)
    set (JSON_SNPRINTF _snprintf)
 endif ()
+
+#
+# Check for existance of isnan and isinf
+#
+set(JSON_ISNAN_ISINF_REQUIRES_LIBM 0)
+set(ISNAN_ISINF_SRC "
+   char isnan();
+   char isinf();
+
+   int main(int argc, char **argv)
+   {
+      isnan();
+      isinf();
+      return 0;
+   }
+   
+   ")
+
+CHECK_C_SOURCE_COMPILES("${ISNAN_ISINF_SRC}" JSON_HAVE_ISNAN_ISINF)
+
+if (NOT JSON_HAVE_ISNAN_ISINF)
+   # Not found, try linking libm and see if it works
+   # uClibc requires this for instance.
+   set(CMAKE_REQUIRED_LIBRARIES m)
+   CHECK_C_SOURCE_COMPILES("${ISNAN_ISINF_SRC}" JSON_HAVE_ISNAN_ISINF_LIBM)
+   set(CMAKE_REQUIRED_LIBRARIES)
+
+   if (JSON_HAVE_ISNAN_ISINF_LIBM)
+      set(JSON_HAVE_ISNAN_ISINF 1)
+      set(JSON_ISNAN_ISINF_REQUIRES_LIBM 1)
+   endif()
+endif()
 
 # Create pkg-conf file.
 # (We use the same files as ./configure does, so we
@@ -443,6 +477,11 @@ if (NOT WITHOUT_TESTS)
        add_executable(${name} ${dir}/${name}.c)
        add_dependencies(${name} jansson)
        target_link_libraries(${name} jansson)
+
+       # uClibc requires libm for some math.h functions.
+       if (JSON_ISNAN_ISINF_REQUIRES_LIBM)
+         target_link_libraries(${name} m)
+       endif()
    endmacro(build_testprog)
 
    # Create executables and tests/valgrind tests for API tests.

--- a/cmake/jansson_config.h.cmake
+++ b/cmake/jansson_config.h.cmake
@@ -57,6 +57,9 @@
 /* If locale.h and localeconv() are available, define to 1, otherwise to 0. */
 #define JSON_HAVE_LOCALECONV @JSON_HAVE_LOCALECONV@
 
-
+/* If isnan() and isinf() are available in math.h, define to 1,
+   otherwise to 0. Note that you may need to link with -lm on some
+   systems. */
+#cmakedefine JSON_HAVE_ISNAN_ISINF 1
 
 #endif


### PR DESCRIPTION
Changed strategy for looking for isnan/isinf that doesnt tie it to uclibc like in #131.
