### PR TITLE
Replace strcpy with memcpy

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -45,7 +45,7 @@ char *jsonp_strdup(const char *str)
     if(!new_str)
         return NULL;
 
-    strcpy(new_str, str);
+    memcpy(new_str, str, len + 1);
     return new_str;
 }
 


### PR DESCRIPTION
Since len is known, the copy function does not need to check byte by byte
the end of the string.

Signed-off-by: Olivier Langlois olivier@olivierlanglois.net
