### PR TITLE
Check for key == NULL in json_object_get and json_object_del

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -76,7 +76,7 @@ json_t *json_object_get(const json_t *json, const char *key)
 {
     json_object_t *object;
 
-    if(!json_is_object(json))
+    if(!key || !json_is_object(json))
         return NULL;
 
     object = json_to_object(json);
@@ -121,7 +121,7 @@ int json_object_del(json_t *json, const char *key)
 {
     json_object_t *object;
 
-    if(!json_is_object(json))
+    if(!key || !json_is_object(json))
         return -1;
 
     object = json_to_object(json);


### PR DESCRIPTION
`json_object_set()` and `json_object_iter_at()` check as well, so it would only be consistent with the rest of the library.
