### PR TITLE
Add CMake build to Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
+env:
+  matrix:
+    - JANSSON_BUILD_METHOD=cmake JANSSON_CMAKE_OPTIONS="-DJANSSON_TEST_WITH_VALGRIND=ON" JANSSON_EXTRA_INSTALL="valgrind"
+    - JANSSON_BUILD_METHOD=autotools
 language: c
 compiler:
   - gcc
   - clang
-script: autoreconf -f -i && CFLAGS=-Werror ./configure && make check
+install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq cmake $JANSSON_EXTRA_INSTALL
+script:
+  - if [ "$JANSSON_BUILD_METHOD" = "autotools" ]; then autoreconf -f -i && CFLAGS=-Werror ./configure && make check; fi
+  - if [ "$JANSSON_BUILD_METHOD" = "cmake" ]; then mkdir build && cd build && cmake .. $JANSSON_CMAKE_OPTIONS && cmake --build . && ctest --output-on-failure; fi


### PR DESCRIPTION
Build both the autotools and cmake project using Travis. (CMake will run valgrind on all tests)

Found out that the valgrind checks doesn't work properly in CMake when doing this, so see #160 for those changes as well.
