### PR TITLE
Add new autotools-generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,14 @@ install-sh
 libtool
 ltmain.sh
 missing
+compile
+test-driver
 *.lo
 *.la
 stamp-h1
 *.pyc
 *.pc
 /src/jansson_config.h
+/jansson_private_config.h.in
+/build
 *.exe


### PR DESCRIPTION
Additionally, `/jansson_private_config.h.in` is also added as well as
"build" directory for those of us who like to use an out-of-tree build
system.
