### PR TITLE
fix build error for android

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -7,6 +7,7 @@ LOCAL_SRC_FILES := \
     src/dump.c \
     src/error.c \
     src/hashtable.c \
+    src/hashtable_seed.c \
     src/load.c \
     src/memory.c \
     src/pack_unpack.c \


### PR DESCRIPTION
Dear devleoper(s),

Currently, it still failed android's build in latest master branch, (below)
Please check & review my patch.
It was verified and fixed in Android KitKat(4.4.2) version.

Regards,
KimJeongYeon

```
target SharedLib: libjansson (out/target/product/generic/obj/SHARED_LIBRARIES/libjansson_intermediates/LINKED/libjansson.so)
external/jansson/src/hashtable.c:246: error: undefined reference to 'hashtable_seed'
external/jansson/src/hashtable.c:275: error: undefined reference to 'hashtable_seed'
external/jansson/src/hashtable.c:119: error: undefined reference to 'hashtable_seed'
external/jansson/src/hashtable.c:318: error: undefined reference to 'hashtable_seed'
external/jansson/src/value.c:59: error: undefined reference to 'json_object_seed'
external/jansson/src/value.c:59: error: undefined reference to 'json_object_seed'
external/jansson/src/value.c:59: error: undefined reference to 'json_object_seed'
collect2: error: ld returned 1 exit status
```
