### PR TITLE
Enable usage of AddressSanitizer to check Jansson

### DIFF
--- a/src/lookup3.h
+++ b/src/lookup3.h
@@ -286,10 +286,6 @@ static uint32_t hashlittle(const void *key, size_t length, uint32_t initval)
 
 #endif /* !valgrind */
 
-#ifdef NO_MASKING_TRICK
-# undef NO_MASKING_TRICK
-#endif
-
   } else if (HASH_LITTLE_ENDIAN && ((u.i & 0x1) == 0)) {
     const uint16_t *k = (const uint16_t *)key;         /* read 16-bit chunks */
     const uint8_t  *k8;


### PR DESCRIPTION
This is just some ifdefs to disable masking trick if build with AddressSanitizer.
I can make modifications for makefiles if you tell me the right way that Jansson uses for such things.
