### PR TITLE
Don't use GNU-make specific export for global AM_CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,8 +8,3 @@ dvi:
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = jansson.pc
-
-if GCC
-# These flags are gcc specific
-export AM_CFLAGS = -Wall -Wextra -Wdeclaration-after-statement
-endif

--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,11 @@ AC_DEFINE([USE_WINDOWS_CRYPTOAPI], [1],
   [Define to 1 if CryptGenRandom should be used for seeding the hash function])
 fi
 
+if test x$GCC = xyes; then
+    AM_CFLAGS="-Wall -Wextra -Wdeclaration-after-statement"
+fi
+AC_SUBST([AM_CFLAGS])
+
 AC_CONFIG_FILES([
         jansson.pc
         Makefile


### PR DESCRIPTION
Just define it at configure time, it's automatically set in all makefiles.

Fixes #203.
