### PR TITLE
Added Windows CI support with appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,6 @@
+build_script:
+  - md build
+  - cd build
+  - cmake ..
+  - cmake --build . --config Release
+  - ctest --output-on-failure


### PR DESCRIPTION
Added support for http://www.appveyor.com/ (login via github account and add the jansson project).

This will build the project and run the unit tests on Windows as well.
Possible to add a badge like with Travis in the README.md as well.
