### PR TITLE
Fix CMake configuration for Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,8 @@ if (MSVC)
    add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /wd4005 /wd4996 /nologo" )
    
    if (JANSSON_STATIC_CRT)
-      set(CMAKE_C_FLAGS_RELEASE "/MT")
-      set(CMAKE_C_FLAGS_DEBUG "/MTd")
+      set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
+      set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
    endif()
    
 endif()


### PR DESCRIPTION
There are two fixes in here:
1. Renaming the options to use the JANSSON_ prefix missed the place where the STATIC_CRT option was actually used
2. When building with STATIC_CRT, the previous CFLAGS are overridden completely, building the Debug configuration with Release flags (e.g. /O2, no /Zi).

I can't find anything in the CMake docs about how the  C_FLAGS variables are supposed to work, but repeating the previous value in the assignment works (it does _not_ pass both /MD and /MT).
