### PR TITLE
64 bit warnings

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -224,8 +224,9 @@ static int do_dump(const json_t *json, size_t flags, int depth,
 
         case JSON_ARRAY:
         {
-            int i;
-            int n;
+            size_t n;
+            size_t i;
+
             json_array_t *array;
 
             /* detect circular references */

--- a/src/error.c
+++ b/src/error.c
@@ -56,7 +56,7 @@ void jsonp_error_vset(json_error_t *error, int line, int column,
 
     error->line = line;
     error->column = column;
-    error->position = position;
+    error->position = (int)position;
 
     vsnprintf(error->text, JSON_ERROR_TEXT_LENGTH, msg, ap);
     error->text[JSON_ERROR_TEXT_LENGTH - 1] = '\0';

--- a/src/load.c
+++ b/src/load.c
@@ -169,7 +169,7 @@ static int stream_get(stream_t *stream, json_error_t *error)
         if(0x80 <= c && c <= 0xFF)
         {
             /* multi-byte UTF-8 sequence */
-            int i, count;
+            size_t i, count;
 
             count = utf8_check_first(c);
             if(!count)
@@ -265,7 +265,7 @@ static void lex_unget_unsave(lex_t *lex, int c)
         #endif
         stream_unget(&lex->stream, c);
         #ifndef NDEBUG
-        d = 
+        d =
         #endif
             strbuffer_pop(&lex->saved_text);
         assert(c == d);
@@ -900,7 +900,7 @@ static json_t *parse_json(lex_t *lex, size_t flags, json_error_t *error)
 
     if(error) {
         /* Save the position even though there was no error */
-        error->position = lex->stream.position;
+        error->position = (int)lex->stream.position;
     }
 
     return result;


### PR DESCRIPTION
Use size_t where appropriate to prevent conversion warnings. 
