### PR TITLE
Allow initial number of initial buckets to be configured

### DIFF
--- a/cmake/jansson_private_config.h.cmake
+++ b/cmake/jansson_private_config.h.cmake
@@ -57,3 +57,5 @@
 
 #cmakedefine USE_URANDOM 1
 #cmakedefine USE_WINDOWS_CRYPTOAPI 1
+
+#define INITIAL_HASHTABLE_ORDER 3

--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,9 @@ AC_DEFINE([USE_WINDOWS_CRYPTOAPI], [1],
   [Define to 1 if CryptGenRandom should be used for seeding the hash function])
 fi
 
+AC_DEFINE([INITIAL_HASHTABLE_ORDER], [3],
+  [Controls the number of hashtable buckets allocated during json_object_t initialization. 2^INITIAL_HASHTABLE_ORDER buckets are created. Default (3) creates 8 buckets.])
+
 if test x$GCC = xyes; then
     AM_CFLAGS="-Wall -Wextra -Wdeclaration-after-statement"
 fi

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -20,10 +20,6 @@
 #include "jansson_private.h"  /* for container_of() */
 #include "hashtable.h"
 
- #ifndef INITIAL_HASHTABLE_ORDER
- #define INITIAL_HASHTABLE_ORDER 3
- #endif
-
 typedef struct hashtable_list list_t;
 typedef struct hashtable_pair pair_t;
 typedef struct hashtable_bucket bucket_t;


### PR DESCRIPTION
In an embedded system with limited memory pools available, upgrading to Jansson 2.6+ had major implications due to the significant increase in memory allocation for an empty object. Many of our objects have just a small handful of key/value pairs and the initial 64-byte allocation for the buckets is wasteful in our case. For situations where many small objects will be allocated, we would like to be able to configure the initial value of `hashtable->order`.

This Pull Request is to suggest two possible solutions, on separate commits. A compile-time option and a run-time option. Theoretically either commit could be cherry-picked.

Please consider including something along these lines in the master branch.

Thanks,
-Chad Barth
