### PR TITLE
Disable warning for deliberate use on MSVS.

### DIFF
--- a/test/suites/api/test_number.c
+++ b/test/suites/api/test_number.c
@@ -9,6 +9,34 @@
 #include <jansson.h>
 #include "util.h"
 
+#ifdef INFINITY
+// This test triggers "warning C4756: overflow in constant arithmetic"
+// in Visual Studio. This warning is triggered here by design, so disable it.
+// (This can only be done on function level so we keep these tests separate)
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning (disable: 4756)
+#endif
+static void test_inifity()
+{
+    json_t *real = json_real(INFINITY);
+    if (real != NULL)
+       fail("could construct a real from Inf");
+
+    real = json_real(1.0);
+    if (json_real_set(real, INFINITY) != -1)
+	    fail("could set a real to Inf");
+
+    if (json_real_value(real) != 1.0)
+       fail("real value changed unexpectedly");
+
+    json_decref(real);
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+}
+#endif // INFINITY
+
 static void run_tests()
 {
     json_t *integer, *real;
@@ -57,17 +85,6 @@ static void run_tests()
 #endif
 
 #ifdef INFINITY
-    real = json_real(INFINITY);
-    if(real != NULL)
-        fail("could construct a real from Inf");
-
-    real = json_real(1.0);
-    if(json_real_set(real, INFINITY) != -1)
-        fail("could set a real to Inf");
-
-    if(json_real_value(real) != 1.0)
-        fail("real value changed unexpectedly");
-
-    json_decref(real);
+    test_inifity();
 #endif
 }


### PR DESCRIPTION
Disable "warning C4756: overflow in constant arithmetic" when deliberately
triggering it in a test using infinity.