### PR TITLE
Added support for passing a user argument to custom memory allocation functions

### DIFF
--- a/src/jansson.h
+++ b/src/jansson.h
@@ -279,9 +279,12 @@ int json_dump_callback(const json_t *json, json_dump_callback_t callback, void *
 /* custom memory allocation */
 
 typedef void *(*json_malloc_t)(size_t);
+typedef void *(*json_malloc_arg_t)(size_t, void*);
 typedef void (*json_free_t)(void *);
+typedef void (*json_free_arg_t)(void *, void*);
 
 void json_set_alloc_funcs(json_malloc_t malloc_fn, json_free_t free_fn);
+void json_set_alloc_funcs_arg(json_malloc_arg_t malloc_fn, json_free_arg_t free_fn, void *arg);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I have added support for passing a user argument to custom memory allocation functions. In particular:

- Two additional types have been created: **json_malloc_arg_t** and **json_free_arg_t**, which are similar to their **json_malloc_t** and **json_free_t** counterparts but the former ones get an extra argument (the user argument).

- A new function has been defined: **json_set_alloc_funcs_arg**. It does the same as its counterpart **json_set_alloc_funcs** but also accepts the user argument that will be passed to custom memory allocation functions. 

Passing NULL as the user argument of **json_set_alloc_funcs_arg** treats the specified functions as user argument-less.