### PR TITLE
use snprintf and strncpy in place of sprintf and strcpy

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -130,7 +130,7 @@ static int dump_string(const char *str, size_t len, json_dump_callback_t dump, v
                 /* codepoint is in BMP */
                 if(codepoint < 0x10000)
                 {
-                    sprintf(seq, "\\u%04X", codepoint);
+                    snprintf(seq, 13, "\\u%04X", codepoint);
                     length = 6;
                 }
 
@@ -143,7 +143,7 @@ static int dump_string(const char *str, size_t len, json_dump_callback_t dump, v
                     first = 0xD800 | ((codepoint & 0xffc00) >> 10);
                     last = 0xDC00 | (codepoint & 0x003ff);
 
-                    sprintf(seq, "\\u%04X\\u%04X", first, last);
+                    snprintf(seq, 13, "\\u%04X\\u%04X", first, last);
                     length = 12;
                 }
 

--- a/src/error.c
+++ b/src/error.c
@@ -25,11 +25,11 @@ void jsonp_error_set_source(json_error_t *error, const char *source)
 
     length = strlen(source);
     if(length < JSON_ERROR_SOURCE_LENGTH)
-        strcpy(error->source, source);
+        strncpy(error->source, source, length + 1);
     else {
         size_t extra = length - JSON_ERROR_SOURCE_LENGTH + 4;
-        strcpy(error->source, "...");
-        strcpy(error->source + 3, source + extra);
+        strncpy(error->source, "...", 3);
+        strncpy(error->source + 3, source + extra, length - extra + 1);
     }
 }
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -251,7 +251,7 @@ int hashtable_set(hashtable_t *hashtable,
 
         pair->hash = hash;
         pair->serial = serial;
-        strcpy(pair->key, key);
+        strncpy(pair->key, key, len + 1);
         pair->value = value;
         list_init(&pair->list);
 


### PR DESCRIPTION
This is both good practice and nice for OpenBSD users, who will no
longer get the nag message to not use sprintf/strcpy every time they
link against jansson. It's worth noting that the existing code seems
safe to me - bounds checks were already happening before the actual
calls - and that this is for extra security.