### PR TITLE
adding (untested) JSON_SEMIPRETTY flag for dumping 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright (c) 2009-2014 Petri Lehtinen <petri@digip.org>
+Copyright (c) 2009-2015 Petri Lehtinen <petri@digip.org>
+and some other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/doc/apiref.rst
+++ b/doc/apiref.rst
@@ -851,9 +851,9 @@ below).
 
 By default, the output has no newlines, and spaces are used between
 array and object elements for a readable output. This behavior can be
-altered by using the ``JSON_INDENT`` and ``JSON_COMPACT`` flags
-described below. A newline is never appended to the end of the encoded
-JSON data.
+altered by using the ``JSON_INDENT``, ``JSON_SEMIPRETTY`` and
+``JSON_COMPACT`` flags described below. A newline is never appended to
+the end of the encoded JSON data.
 
 Each function takes a *flags* parameter that controls some aspects of
 how the data is encoded. Its default value is 0. The following macros
@@ -871,6 +871,16 @@ can be ORed together to obtain *flags*.
 
    .. versionchanged:: 2.7
       Added ``JSON_MAX_INDENT``.
+
+``JSON_SEMIPRETTY``
+
+   Can be used with ``JSON_INDENT(n)``; indented newlines are not
+   always emitted, but only when the current line is larger than
+   *64+n* bytes. So the output looks half-pretty, but has much less
+   line indentation than without this flag.
+  
+   .. versionchanged:: 2.8
+   
 
 ``JSON_COMPACT``
    This flag enables a compact representation, i.e. sets the separator

--- a/src/dump.c
+++ b/src/dump.c
@@ -46,14 +46,27 @@ static int dump_to_file(const char *buffer, size_t size, void *data)
 /* 32 spaces (the maximum indentation size) */
 static const char whitespace[] = "                                ";
 
-static int dump_indent(size_t flags, int depth, int space, json_dump_callback_t dump, void *data)
+#define SEMIPRETTY_INDENT_THRESHOLD 64
+
+static int dump_indent(size_t flags, int depth, int space, long *pcol, json_dump_callback_t dump, void *data)
 {
     if(FLAGS_TO_INDENT(flags) > 0)
     {
         unsigned int ws_count = FLAGS_TO_INDENT(flags), n_spaces = depth * ws_count;
 
+	if (flags & JSON_SEMIPRETTY) {
+	  if (*pcol < SEMIPRETTY_INDENT_THRESHOLD + FLAGS_TO_INDENT(flags))
+	    {
+	      if (space && !(flags & JSON_COMPACT)) {
+		(*pcol) ++;
+		return dump(" ", 1, data);
+	      }
+	      else return 0;
+	    };
+	}
         if(dump("\n", 1, data))
             return -1;
+	(*pcol) = 0;
 
         while(n_spaces > 0)
         {
@@ -61,24 +74,27 @@ static int dump_indent(size_t flags, int depth, int space, json_dump_callback_t 
 
             if(dump(whitespace, cur_n, data))
                 return -1;
-
+	    (*pcol) += cur_n;
             n_spaces -= cur_n;
         }
     }
     else if(space && !(flags & JSON_COMPACT))
     {
+        (*pcol) ++;
         return dump(" ", 1, data);
     }
     return 0;
 }
 
-static int dump_string(const char *str, size_t len, json_dump_callback_t dump, void *data, size_t flags)
+
+static int dump_string(const char *str, size_t len, json_dump_callback_t dump, long*pcol, void *data, size_t flags)
 {
     const char *pos, *end, *lim;
     int32_t codepoint;
 
     if(dump("\"", 1, data))
         return -1;
+    (*pcol)++;
 
     end = pos = str;
     lim = str + len;
@@ -112,6 +128,7 @@ static int dump_string(const char *str, size_t len, json_dump_callback_t dump, v
         if(pos != str) {
             if(dump(str, pos - str, data))
                 return -1;
+	    *pcol += (pos - str);
         }
 
         if(end == pos)
@@ -158,10 +175,12 @@ static int dump_string(const char *str, size_t len, json_dump_callback_t dump, v
 
         if(dump(text, length, data))
             return -1;
+	*pcol += length;
 
         str = pos = end;
     }
 
+    (*pcol) ++;
     return dump("\"", 1, data);
 }
 
@@ -180,6 +199,7 @@ static int object_key_compare_serials(const void *key1, const void *key2)
 }
 
 static int do_dump(const json_t *json, size_t flags, int depth,
+		   long*pcol,
                    json_dump_callback_t dump, void *data)
 {
     if(!json)
@@ -187,12 +207,15 @@ static int do_dump(const json_t *json, size_t flags, int depth,
 
     switch(json_typeof(json)) {
         case JSON_NULL:
+	    *pcol += 4;
             return dump("null", 4, data);
 
         case JSON_TRUE:
+	    *pcol += 4;
             return dump("true", 4, data);
 
         case JSON_FALSE:
+	    *pcol += 5;
             return dump("false", 5, data);
 
         case JSON_INTEGER:
@@ -205,7 +228,7 @@ static int do_dump(const json_t *json, size_t flags, int depth,
                             json_integer_value(json));
             if(size < 0 || size >= MAX_INTEGER_STR_LENGTH)
                 return -1;
-
+            *pcol += size;
             return dump(buffer, size, data);
         }
 
@@ -219,12 +242,12 @@ static int do_dump(const json_t *json, size_t flags, int depth,
                                 FLAGS_TO_PRECISION(flags));
             if(size < 0)
                 return -1;
-
+            *pcol += size;
             return dump(buffer, size, data);
         }
 
         case JSON_STRING:
-            return dump_string(json_string_value(json), json_string_length(json), dump, data, flags);
+	  return dump_string(json_string_value(json), json_string_length(json), pcol, dump, data, flags);
 
         case JSON_ARRAY:
         {
@@ -243,32 +266,36 @@ static int do_dump(const json_t *json, size_t flags, int depth,
 
             if(dump("[", 1, data))
                 goto array_error;
+	    (*pcol) ++;
             if(n == 0) {
                 array->visited = 0;
+		(*pcol) ++;
                 return dump("]", 1, data);
             }
-            if(dump_indent(flags, depth + 1, 0, dump, data))
+            if(dump_indent(flags, depth + 1, 0, pcol, dump, data))
                 goto array_error;
 
             for(i = 0; i < n; ++i) {
                 if(do_dump(json_array_get(json, i), flags, depth + 1,
+			   pcol,
                            dump, data))
                     goto array_error;
 
                 if(i < n - 1)
                 {
                     if(dump(",", 1, data) ||
-                       dump_indent(flags, depth + 1, 1, dump, data))
+                       dump_indent(flags, depth + 1, 1, pcol, dump, data))
                         goto array_error;
                 }
                 else
                 {
-                    if(dump_indent(flags, depth, 0, dump, data))
+                    if(dump_indent(flags, depth, 0, pcol, dump, data))
                         goto array_error;
                 }
             }
 
             array->visited = 0;
+	    (*pcol) ++;
             return dump("]", 1, data);
 
         array_error:
@@ -302,11 +329,13 @@ static int do_dump(const json_t *json, size_t flags, int depth,
 
             if(dump("{", 1, data))
                 goto object_error;
+	    (*pcol) ++;
             if(!iter) {
                 object->visited = 0;
+		(*pcol) ++;
                 return dump("}", 1, data);
             }
-            if(dump_indent(flags, depth + 1, 0, dump, data))
+            if(dump_indent(flags, depth + 1, 0, pcol, dump, data))
                 goto object_error;
 
             if(flags & JSON_SORT_KEYS || flags & JSON_PRESERVE_ORDER)
@@ -346,18 +375,22 @@ static int do_dump(const json_t *json, size_t flags, int depth,
                     value = json_object_get(json, key);
                     assert(value);
 
-                    dump_string(key, strlen(key), dump, data, flags);
+                    dump_string(key, strlen(key), dump, pcol, data, flags);
                     if(dump(separator, separator_length, data) ||
-                       do_dump(value, flags, depth + 1, dump, data))
+                       do_dump(value, flags, depth + 1,
+			       pcol,
+			       dump, data))
                     {
                         jsonp_free(keys);
                         goto object_error;
                     }
+		    (*pcol) += separator_length;
 
                     if(i < size - 1)
                     {
+		        (*pcol) ++;
                         if(dump(",", 1, data) ||
-                           dump_indent(flags, depth + 1, 1, dump, data))
+                           dump_indent(flags, depth + 1, 1, pcol, dump, data))
                         {
                             jsonp_free(keys);
                             goto object_error;
@@ -365,7 +398,7 @@ static int do_dump(const json_t *json, size_t flags, int depth,
                     }
                     else
                     {
-                        if(dump_indent(flags, depth, 0, dump, data))
+		      if(dump_indent(flags, depth, 0, pcol, dump, data))
                         {
                             jsonp_free(keys);
                             goto object_error;
@@ -384,21 +417,24 @@ static int do_dump(const json_t *json, size_t flags, int depth,
                     void *next = json_object_iter_next((json_t *)json, iter);
                     const char *key = json_object_iter_key(iter);
 
-                    dump_string(key, strlen(key), dump, data, flags);
+                    dump_string(key, strlen(key), dump, pcol, data, flags);
+		    *pcol += separator_length;
                     if(dump(separator, separator_length, data) ||
                        do_dump(json_object_iter_value(iter), flags, depth + 1,
+			       pcol,
                                dump, data))
                         goto object_error;
 
                     if(next)
                     {
+		        *pcol ++;
                         if(dump(",", 1, data) ||
-                           dump_indent(flags, depth + 1, 1, dump, data))
+                           dump_indent(flags, depth + 1, 1, pcol, dump, data))
                             goto object_error;
                     }
                     else
                     {
-                        if(dump_indent(flags, depth, 0, dump, data))
+		        if(dump_indent(flags, depth, 0, pcol, dump, data))
                             goto object_error;
                     }
 
@@ -407,6 +443,7 @@ static int do_dump(const json_t *json, size_t flags, int depth,
             }
 
             object->visited = 0;
+	    (*pcol) ++;
             return dump("}", 1, data);
 
         object_error:
@@ -439,7 +476,7 @@ char *json_dumps(const json_t *json, size_t flags)
 
 int json_dumpf(const json_t *json, FILE *output, size_t flags)
 {
-    return json_dump_callback(json, dump_to_file, (void *)output, flags);
+  return json_dump_callback(json, dump_to_file, (void *)output, flags);
 }
 
 int json_dump_file(const json_t *json, const char *path, size_t flags)
@@ -450,7 +487,7 @@ int json_dump_file(const json_t *json, const char *path, size_t flags)
     if(!output)
         return -1;
 
-    result = json_dumpf(json, output, flags);
+      result = json_dumpf(json, output, flags);
 
     fclose(output);
     return result;
@@ -463,5 +500,6 @@ int json_dump_callback(const json_t *json, json_dump_callback_t callback, void *
            return -1;
     }
 
-    return do_dump(json, flags, 0, callback, data);
+    long col = 0;
+    return do_dump(json, flags, 0, &col, callback, data);
 }

--- a/src/jansson.h
+++ b/src/jansson.h
@@ -267,7 +267,8 @@ json_t *json_load_callback(json_load_callback_t callback, void *data, size_t fla
 #define JSON_PRESERVE_ORDER     0x100
 #define JSON_ENCODE_ANY         0x200
 #define JSON_ESCAPE_SLASH       0x400
-#define JSON_REAL_PRECISION(n)  (((n) & 0x1F) << 11)
+#define JSON_SEMIPRETTY         0x800
+#define JSON_REAL_PRECISION(n)  (((n) & 0x1F) << 12)
 
 typedef int (*json_dump_callback_t)(const char *buffer, size_t size, void *data);
 


### PR DESCRIPTION
This is an untested patch (because I am not familiar with the test suite).

It adds a JSON_SEMIPRETTY flag for dumping. When this flag is set, indenting does not always occur as in `JSON_INDENT(n)` but only when the output "line" is larger than 64 + indentation level.

Hence, small objects like `{ "foo": 1, "bar": [false] }` would be dumped in a single line, but large objects would be a bit indented.