### PR TITLE
Added "flags" field and getter/setter functions for "flags" field

### DIFF
--- a/src/jansson.h
+++ b/src/jansson.h
@@ -50,6 +50,7 @@ typedef enum {
 typedef struct json_t {
     json_type type;
     size_t refcount;
+	boolean is_modified;
 } json_t;
 
 #ifndef JANSSON_USING_CMAKE /* disabled if using cmake */
@@ -78,6 +79,7 @@ typedef long json_int_t;
 #define json_boolean_value     json_is_true
 #define json_is_boolean(json)  (json_is_true(json) || json_is_false(json))
 #define json_is_null(json)     ((json) && json_typeof(json) == JSON_NULL)
+#define json_is_modified(json) ((json)->is_modified)
 
 /* construction, destruction, reference counting */
 
@@ -128,6 +130,8 @@ typedef struct {
 
 
 /* getters, setters, manipulation */
+
+int json_set_modified(json_t *json_object, bool input);
 
 void json_object_seed(size_t seed);
 size_t json_object_size(const json_t *object);

--- a/src/jansson.h
+++ b/src/jansson.h
@@ -50,7 +50,6 @@ typedef enum {
 typedef struct json_t {
     json_type type;
     size_t refcount;
-	boolean is_modified;
 } json_t;
 
 #ifndef JANSSON_USING_CMAKE /* disabled if using cmake */
@@ -79,7 +78,6 @@ typedef long json_int_t;
 #define json_boolean_value     json_is_true
 #define json_is_boolean(json)  (json_is_true(json) || json_is_false(json))
 #define json_is_null(json)     ((json) && json_typeof(json) == JSON_NULL)
-#define json_is_modified(json) ((json)->is_modified)
 
 /* construction, destruction, reference counting */
 
@@ -130,8 +128,6 @@ typedef struct {
 
 
 /* getters, setters, manipulation */
-
-int json_set_modified(json_t *json_object, bool input);
 
 void json_object_seed(size_t seed);
 size_t json_object_size(const json_t *object);

--- a/src/value.c
+++ b/src/value.c
@@ -914,21 +914,21 @@ double json_number_value(const json_t *json)
 
 json_t *json_true(void)
 {
-    static json_t the_true = {JSON_TRUE, (size_t)-1};
+    static json_t the_true = {JSON_TRUE, (size_t)-1, 0};
     return &the_true;
 }
 
 
 json_t *json_false(void)
 {
-    static json_t the_false = {JSON_FALSE, (size_t)-1};
+    static json_t the_false = {JSON_FALSE, (size_t)-1, 0};
     return &the_false;
 }
 
 
 json_t *json_null(void)
 {
-    static json_t the_null = {JSON_NULL, (size_t)-1};
+    static json_t the_null = {JSON_NULL, (size_t)-1, 0};
     return &the_null;
 }
 

--- a/src/value.c
+++ b/src/value.c
@@ -44,6 +44,11 @@ static JSON_INLINE void json_init(json_t *json, json_type type)
 }
 
 
+int json_set_modified(json_t *json_object, bool input)
+{
+	json_object->is_modified = input;
+}
+
 /*** object ***/
 
 extern volatile uint32_t hashtable_seed;

--- a/src/value.c
+++ b/src/value.c
@@ -44,11 +44,6 @@ static JSON_INLINE void json_init(json_t *json, json_type type)
 }
 
 
-int json_set_modified(json_t *json_object, bool input)
-{
-	json_object->is_modified = input;
-}
-
 /*** object ***/
 
 extern volatile uint32_t hashtable_seed;


### PR DESCRIPTION
Added field of type "unsigned char" with name "flags" along with json_get_flags() and json_set_flags() getter/setter functions to be used by users of libjansson for saving per node flags that are opaque to libjansson itself.