### PR TITLE
Update test_memory_funcs.c

### DIFF
--- a/test/suites/api/test_memory_funcs.c
+++ b/test/suites/api/test_memory_funcs.c
@@ -11,7 +11,7 @@ static void create_and_free_complex_object()
 {
     json_t *obj;
 
-    obj = json_pack("{s:i,s:n,s:b,s:b,s:{s:s},s:[i,i,i]",
+    obj = json_pack("{s:i,s:n,s:b,s:b,s:{s:s},s:[i,i,i]}",
                     "foo", 42,
                     "bar",
                     "baz", 1,


### PR DESCRIPTION
cannot test "test_memory_funcs.c" because its sample format missed "}"