### PR TITLE
FIX CMake snprintf DETECTION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ include (CheckFunctionExists)
 include (CheckFunctionKeywords)
 include (CheckIncludeFiles)
 include (CheckTypeSize)
+include (CheckSymbolExists)
 
 if (MSVC)
    # Turn off Microsofts "security" warnings.
@@ -304,8 +305,8 @@ else()
 endif()
 
 # Find our snprintf
-check_function_exists (snprintf HAVE_SNPRINTF)
-check_function_exists (_snprintf HAVE__SNPRINTF)
+check_symbol_exists(snprintf stdio.h HAVE_SNPRINTF)
+check_symbol_exists(_snprintf stdio.h HAVE__SNPRINTF)
 
 if (HAVE_SNPRINTF)
    set(JSON_SNPRINTF snprintf)


### PR DESCRIPTION
Replace check_function_exists calls with check_symbol_exists calls for
snprintf detection because starting with MSVC 19 snprintf is declared as
an inline function thus check_function_exists fails to detect it.
(See http://public.kitware.com/Bug/view.php?id=15659)