### PR TITLE
Improve usage of snprintf in dump.c

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -134,7 +134,7 @@ static int dump_string(const char *str, size_t len, json_dump_callback_t dump, v
                 /* codepoint is in BMP */
                 if(codepoint < 0x10000)
                 {
-                    snprintf(seq, 13, "\\u%04X", codepoint);
+                    snprintf(seq, sizeof(seq), "\\u%04X", codepoint);
                     length = 6;
                 }
 
@@ -147,7 +147,7 @@ static int dump_string(const char *str, size_t len, json_dump_callback_t dump, v
                     first = 0xD800 | ((codepoint & 0xffc00) >> 10);
                     last = 0xDC00 | (codepoint & 0x003ff);
 
-                    snprintf(seq, 13, "\\u%04X\\u%04X", first, last);
+                    snprintf(seq, sizeof(seq), "\\u%04X\\u%04X", first, last);
                     length = 12;
                 }
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -134,7 +134,7 @@ static int dump_string(const char *str, size_t len, json_dump_callback_t dump, v
                 /* codepoint is in BMP */
                 if(codepoint < 0x10000)
                 {
-                    snprintf(seq, sizeof(seq), "\\u%04X", codepoint);
+                    snprintf(seq, sizeof(seq), "\\u%04X", (unsigned int)codepoint);
                     length = 6;
                 }
 
@@ -147,7 +147,7 @@ static int dump_string(const char *str, size_t len, json_dump_callback_t dump, v
                     first = 0xD800 | ((codepoint & 0xffc00) >> 10);
                     last = 0xDC00 | (codepoint & 0x003ff);
 
-                    snprintf(seq, sizeof(seq), "\\u%04X\\u%04X", first, last);
+                    snprintf(seq, sizeof(seq), "\\u%04X\\u%04X", (unsigned int)first, (unsigned int)last);
                     length = 12;
                 }
 


### PR DESCRIPTION
Be more explicit about casting arguments to snprintf.

Use sizeof() instead of magic constant.