### PR TITLE
add auto_json_decref macro

### DIFF
--- a/src/jansson.h
+++ b/src/jansson.h
@@ -112,6 +112,20 @@ void json_decref(json_t *json)
         json_delete(json);
 }
 
+#ifdef __GNUC__
+#define auto_json_decref __attribute((cleanup(json_autodecref)))
+static JSON_INLINE
+void json_autodecref(json_t **json)
+{
+    if(!json)
+        return;
+    if(!*json)
+        return;
+    json_decref(*json);
+    *json = NULL;
+}
+#endif
+
 
 /* error reporting */
 


### PR DESCRIPTION
gcc and clang implement the compiler attribute cleanup() [1] which lets
you add a function call that is invoked as soon as a variable goes out
of scope.

This feature improves code where you retrieve a json_t object at one
point and you're not interested to keep it over a longer period of time.

[1] https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-g_t_0040code_007bcleanup_007d-variable-attribute-3485