### PR TITLE
WIP/RFC: set errno to avoid return value ambiguity

### DIFF
--- a/doc/apiref.rst
+++ b/doc/apiref.rst
@@ -581,27 +581,27 @@ allowed in object keys.
 
    .. refcounting:: new
 
-   Returns a new JSON object, or *NULL* on error. Initially, the
-   object is empty.
+   Returns a new JSON object, or *NULL* on memory allocation failure. Initially,
+   the object is empty.
 
 .. function:: size_t json_object_size(const json_t *object)
 
-   Returns the number of elements in *object*, or 0 if *object* is not
-   a JSON object.
+   Returns the number of elements in *object*, or returns 0 and sets *errno* if
+   *object* is not a JSON object.
 
 .. function:: json_t *json_object_get(const json_t *object, const char *key)
 
    .. refcounting:: borrow
 
    Get a value corresponding to *key* from *object*. Returns *NULL* if
-   *key* is not found and on error.
+   *key* is not found, and returns *NULL* and sets *errno* on error.
 
 .. function:: int json_object_set(json_t *object, const char *key, json_t *value)
 
    Set the value of *key* to *value* in *object*. *key* must be a
    valid null terminated UTF-8 encoded Unicode string. If there
    already is a value for *key*, it is replaced by the new value.
-   Returns 0 on success and -1 on error.
+   On success returns 0 and on error returns -1 and sets *errno*.
 
 .. function:: int json_object_set_nocheck(json_t *object, const char *key, json_t *value)
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -9,6 +9,7 @@
 #include <jansson_private_config.h>
 #endif
 
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -161,7 +162,7 @@ static int hashtable_do_rehash(hashtable_t *hashtable)
 
     hashtable->buckets = jsonp_malloc(new_size * sizeof(bucket_t));
     if(!hashtable->buckets)
-        return -1;
+        return ENOMEM;
 
     for(i = 0; i < hashsize(hashtable->order); i++)
     {


### PR DESCRIPTION
In some situations, such as `json_object_size()`, `json_object_get()`, and
`json_string_length()`, it is ambiguous whether a return value indicates an
error. Setting errno on error is one way to avoid this.

Is this a direction worth pursuing? This already demonstrates the general shape
of approach I'd take: return specific error codes from internal functions, set
errno to them, and leave the external functions' return values unchanged. This
would open up the option of documenting possible errors in more detail.