### PR TITLE
OOM crash 

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -152,16 +152,18 @@ static int hashtable_do_rehash(hashtable_t *hashtable)
 {
     list_t *list, *next;
     pair_t *pair;
-    size_t i, index, new_size;
+    size_t i, index, new_size, new_order;
+
+    new_order = hashtable->order + 1;
+    new_size = hashsize(new_order);
+
+    struct hashtable_bucket *new_buckets = jsonp_malloc(new_size * sizeof(bucket_t));
+    if(!new_buckets)
+        return -1;
 
     jsonp_free(hashtable->buckets);
-
-    hashtable->order++;
-    new_size = hashsize(hashtable->order);
-
-    hashtable->buckets = jsonp_malloc(new_size * sizeof(bucket_t));
-    if(!hashtable->buckets)
-        return -1;
+    hashtable->buckets = new_buckets;
+    hashtable->order = new_order;
 
     for(i = 0; i < hashsize(hashtable->order); i++)
     {

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -153,11 +153,12 @@ static int hashtable_do_rehash(hashtable_t *hashtable)
     list_t *list, *next;
     pair_t *pair;
     size_t i, index, new_size, new_order;
+    struct hashtable_bucket *new_buckets;
 
     new_order = hashtable->order + 1;
     new_size = hashsize(new_order);
 
-    struct hashtable_bucket *new_buckets = jsonp_malloc(new_size * sizeof(bucket_t));
+    new_buckets = jsonp_malloc(new_size * sizeof(bucket_t));
     if(!new_buckets)
         return -1;
 

--- a/test/suites/api/test_memory_funcs.c
+++ b/test/suites/api/test_memory_funcs.c
@@ -25,11 +25,12 @@ static void create_and_free_complex_object()
 
 static void create_and_free_object_with_oom()
 {
+    int i;
+    char key[4];
     json_t *obj = json_object();
 
-    for (int i = 0; i < 10; i++)
+    for (i = 0; i < 10; i++)
     {
-        char key[4];
         snprintf(key, sizeof key, "%d", i);
         json_object_set_new(obj, key, json_integer(i));
     }

--- a/test/suites/api/test_memory_funcs.c
+++ b/test/suites/api/test_memory_funcs.c
@@ -5,8 +5,9 @@
 
 static int malloc_called = 0;
 static int free_called = 0;
+static size_t malloc_used = 0;
 
-/* helper */
+/* helpers */
 static void create_and_free_complex_object()
 {
     json_t *obj;
@@ -18,6 +19,20 @@ static void create_and_free_complex_object()
                     "qux", 0,
                     "alice", "bar", "baz",
                     "bob", 9, 8, 7);
+
+    json_decref(obj);
+}
+
+static void create_and_free_object_with_oom()
+{
+    json_t *obj = json_object();
+
+    for (int i = 0; i < 10; i++)
+    {
+        char key[4];
+        snprintf(key, sizeof key, "%d", i);
+        json_object_set_new(obj, key, json_integer(i));
+    }
 
     json_decref(obj);
 }
@@ -46,6 +61,32 @@ static void test_simple()
     if (malloc_called != 1 || free_called != 1
         || mfunc != my_malloc || ffunc != my_free)
         fail("Custom allocation failed");
+}
+
+
+static void *oom_malloc(size_t size)
+{
+    if (malloc_used + size > 800)
+        return NULL;
+
+    malloc_used += size;
+    return malloc(size);
+}
+
+static void oom_free(void *ptr)
+{
+    free_called++;
+    free(ptr);
+}
+
+static void test_oom()
+{
+    free_called = 0;
+    json_set_alloc_funcs(oom_malloc, oom_free);
+    create_and_free_object_with_oom();
+
+    if (free_called == 0)
+        fail("Allocation with OOM failed");
 }
 
 
@@ -84,4 +125,5 @@ static void run_tests()
 {
     test_simple();
     test_secure_funcs();
+    test_oom();
 }


### PR DESCRIPTION
I have a case with a crash after OOM due to `hashtable->buckets` being `NULL` in `hashtable_set()`. 
Here is a test case which reproduces it and a proposed fix.