### PR TITLE
Add configure script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ config.h.in
 config.log
 config.status
 config.sub
-configure
 depcomp
 install-sh
 libtool

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,6 +609,7 @@ endforeach()
 set(prefix      ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix ${CMAKE_INSTALL_PREFIX})
 set(libdir      ${JANSSON_INSTALL_LIB_DIR})
+set(includedir  ${JANSSON_INSTALL_INCLUDE_DIR})
 set(VERSION     ${JANSSON_DISPLAY_VERSION})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/jansson.pc.in
                ${CMAKE_CURRENT_BINARY_DIR}/jansson.pc @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,16 +595,6 @@ endif()
 
 set(JANSSON_INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
 
-# Create pkg-conf file.
-# (We use the same files as ./configure does, so we
-#  have to defined the same variables used there).
-set(prefix      ${CMAKE_INSTALL_PREFIX})
-set(exec_prefix ${CMAKE_INSTALL_PREFIX})
-set(libdir      ${CMAKE_INSTALL_PREFIX}/${JANSSON_INSTALL_LIB_DIR})
-set(VERSION     ${JANSSON_DISPLAY_VERSION})
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/jansson.pc.in
-               ${CMAKE_CURRENT_BINARY_DIR}/jansson.pc @ONLY)
-
 # Make sure the paths are absolute.
 foreach(p LIB BIN INCLUDE CMAKE)
     set(var JANSSON_INSTALL_${p}_DIR)
@@ -612,6 +602,16 @@ foreach(p LIB BIN INCLUDE CMAKE)
         set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
     endif()
 endforeach()
+
+# Create pkg-conf file.
+# (We use the same files as ./configure does, so we
+#  have to defined the same variables used there).
+set(prefix      ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix ${CMAKE_INSTALL_PREFIX})
+set(libdir      ${JANSSON_INSTALL_LIB_DIR})
+set(VERSION     ${JANSSON_DISPLAY_VERSION})
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/jansson.pc.in
+               ${CMAKE_CURRENT_BINARY_DIR}/jansson.pc @ONLY)
 
 # Export targets (This is used for other CMake projects to easily find the libraries and include files).
 export(TARGETS jansson

--- a/configure
+++ b/configure
@@ -1,0 +1,63 @@
+#!/bin/bash
+# configure script adapter for cmake
+# Copyright 2010, 2011, 2013 Colin Walters <walters@verbum.org>
+# Licensed under the new-BSD license (http://www.opensource.org/licenses/bsd-license.php)
+
+prefix=/usr
+
+# Little helper function for reading args from the commandline.
+# it automatically handles -a b and -a=b variants, and returns 1 if
+# we need to shift $3.
+read_arg() {
+    # $1 = arg name
+    # $2 = arg value
+    # $3 = arg parameter
+    local rematch='^[^=]*=(.*)$'
+    if [[ $2 =~ $rematch ]]; then
+        read "$1" <<< "${BASH_REMATCH[1]}"
+    else
+        read "$1" <<< "$3"
+        # There is no way to shift our callers args, so
+        # return 1 to indicate they should do it instead.
+        return 1
+    fi
+}
+
+disable_documentation=false
+enable_shared=false
+
+while (($# > 0)); do
+    case "${1%%=*}" in
+        --prefix) read_arg prefix "$@" || shift;;
+        --bindir) read_arg bindir "$@" || shift;;
+        --sbindir) read_arg sbindir "$@" || shift;;
+        --libexecdir) read_arg libexecdir "$@" || shift;;
+        --datarootdir) read_arg datarootdir "$@" || shift;;
+        --datadir) read_arg datadir "$@" || shift;;
+        --sysconfdir) read_arg sysconfdir "$@" || shift;;
+        --libdir) read_arg libdir "$@" || shift;;
+        --mandir) read_arg mandir "$@" || shift;;
+        --disable-documentation)  disable_documentation=true ;;
+        --enable-shared)  enable_shared=true ;;
+        *) echo "Ignoring unknown option '$1'";;
+    esac
+    shift
+done
+
+bindir=${bindir:-$prefix/bin}
+libdir=${libdir:-$prefix/lib}
+
+srcdir=$(dirname $0)
+
+opts=
+$disable_documentation && opts="$opts -DJANSSON_BUILD_DOCS=OFF"
+$enable_shared && opts="$opts -DJANSSON_BUILD_SHARED_LIBS=ON"
+
+cmake \
+     "-DCMAKE_INSTALL_PREFIX:PATH=$prefix" \
+     "-DJANSSON_INSTALL_LIB_DIR:PATH=$libdir" \
+     "-DJANSSON_INSTALL_BIN_DIR:PATH=$bindir" \
+     "-DJANSSON_INSTALL_INCLUDE_DIR:PATH=$prefix/include" \
+     "-DJANSSON_INSTALL_CMAKE_DIR:PATH=$libdir/cmake" \
+     $opts \
+     ${srcdir}

--- a/jansson.pc.in
+++ b/jansson.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=${prefix}/include
+includedir=@includedir@
 
 Name: Jansson
 Description: Library for encoding, decoding and manipulating JSON data


### PR DESCRIPTION
Continuous integration and other mass-build tasks can be simplified if projects have a uniform way to be compiled without a lot of per-project setup. See http://people.gnome.org/~walters/docs/build-api.txt for details. This PR adds a wrapper configure script that accepts common options like --prefix and --libdir and runs cmake.
