### PR TITLE
part of conditional expression is always true (!done)

### DIFF
--- a/src/hashtable_seed.c
+++ b/src/hashtable_seed.c
@@ -168,12 +168,12 @@ static uint32_t generate_seed() {
     int done = 0;
 
 #if !defined(_WIN32) && defined(USE_URANDOM)
-    if (!done && seed_from_urandom(&seed) == 0)
+    if (seed_from_urandom(&seed) == 0)
         done = 1;
 #endif
 
 #if defined(_WIN32) && defined(USE_WINDOWS_CRYPTOAPI)
-    if (!done && seed_from_windows_cryptoapi(&seed) == 0)
+    if (seed_from_windows_cryptoapi(&seed) == 0)
         done = 1;
 #endif
 


### PR DESCRIPTION
pvs-studio reports this issue as

```
src/hashtable_seed.c<#~>error<#~>V560<#~>A part of conditional expression is always true: 
	!done.<#~>false<#~>2<#~>#if !defined(_WIN32) && defined(USE_URANDOM)<#~>
    if (!done && seed_from_urandom(&seed) == 0)<#~>        done = 1;<#~>
```