### PR TITLE
json_dump_file API returns success even when fclose fails

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -481,7 +481,9 @@ int json_dump_file(const json_t *json, const char *path, size_t flags)
 
     result = json_dumpf(json, output, flags);
 
-    fclose(output);
+    if(fclose(output) != 0)
+        return -1;
+
     return result;
 }
 


### PR DESCRIPTION
json_dump_file API should check the return value of fclose before returning success to its caller. fwrite may not write anything into the file, it simply returns the the number of bytes written into the buffer and that's what the API is returning. 
Consider the case when disk is full in such a case we would still return success,  but, it'll result in truncation of the file (resulting in zero sized file).  Since, API might return false success in error condition, its caller can't take any remedial action on the failure. I had such a scenario, where, based on this API's success I was overwriting a backup file, thereby resulting in total loss of data. 
We should check if fclose is successful or not before sending the final return value. 