### PR TITLE
Add JSON_TRAILING_LINEFEED encoding flag

### DIFF
--- a/doc/apiref.rst
+++ b/doc/apiref.rst
@@ -947,6 +947,13 @@ can be ORed together to obtain *flags*.
 
    .. versionadded:: 2.10
 
+``JSON_TRAILING_LINEFEED``
+   If this flag is used, a trailing newline is added to dump output.
+   This is required for compliance with the POSIX definition of a text file,
+   and is helpful when working with Unix-like utilities.
+
+   .. versionadded:: 2.11
+
 These functions output UTF-8:
 
 .. function:: char *json_dumps(const json_t *json, size_t flags)

--- a/src/jansson.h
+++ b/src/jansson.h
@@ -290,6 +290,7 @@ json_t *json_load_callback(json_load_callback_t callback, void *data, size_t fla
 #define JSON_ESCAPE_SLASH       0x400
 #define JSON_REAL_PRECISION(n)  (((n) & 0x1F) << 11)
 #define JSON_EMBED              0x10000
+#define JSON_TRAILING_LINEFEED  0x20000
 
 typedef int (*json_dump_callback_t)(const char *buffer, size_t size, void *data);
 

--- a/test/suites/api/test_dump.c
+++ b/test/suites/api/test_dump.c
@@ -311,6 +311,72 @@ static void embed()
     }
 }
 
+static void trailing_linefeed()
+{
+    /* Encode each type with a trailing linefeed */
+
+    json_t *json;
+    char *result;
+
+    json = json_object();
+    json_object_set_new(json, "foo", json_integer(5));
+    result = json_dumps(json, JSON_TRAILING_LINEFEED);
+    if(!result || strcmp(result, "{\"foo\": 5}\n"))
+        fail("json_dumps failed");
+    free(result);
+    json_decref(json);
+
+    json = json_array();
+    json_array_append_new(json, json_integer(5));
+    result = json_dumps(json, JSON_TRAILING_LINEFEED);
+    if(!result || strcmp(result, "[5]\n"))
+        fail("json_dumps failed");
+    free(result);
+    json_decref(json);
+
+    json = json_string("bar");
+    result = json_dumps(json, JSON_TRAILING_LINEFEED | JSON_ENCODE_ANY);
+    if(!result || strcmp(result, "\"bar\"\n"))
+        fail("json_dumps failed");
+    free(result);
+    json_decref(json);
+
+    json = json_integer(5);
+    result = json_dumps(json, JSON_TRAILING_LINEFEED | JSON_ENCODE_ANY);
+    if(!result || strcmp(result, "5\n"))
+        fail("json_dumps failed");
+    free(result);
+    json_decref(json);
+
+    json = json_real(5.5);
+    result = json_dumps(json, JSON_TRAILING_LINEFEED | JSON_ENCODE_ANY);
+    if(!result || strcmp(result, "5.5\n"))
+        fail("json_dumps failed");
+    free(result);
+    json_decref(json);
+
+    json = json_true();
+    result = json_dumps(json, JSON_TRAILING_LINEFEED | JSON_ENCODE_ANY);
+    if(!result || strcmp(result, "true\n"))
+        fail("json_dumps failed");
+    free(result);
+    json_decref(json);
+
+    json = json_false();
+    result = json_dumps(json, JSON_TRAILING_LINEFEED | JSON_ENCODE_ANY);
+    if(!result || strcmp(result, "false\n"))
+        fail("json_dumps failed");
+    free(result);
+    json_decref(json);
+
+    json = json_null();
+    result = json_dumps(json, JSON_TRAILING_LINEFEED | JSON_ENCODE_ANY);
+    if(!result || strcmp(result, "null\n"))
+        fail("json_dumps failed");
+    free(result);
+    json_decref(json);
+}
+
 static void run_tests()
 {
     encode_null();
@@ -323,4 +389,5 @@ static void run_tests()
     dumpb();
     dumpfd();
     embed();
+    trailing_linefeed();
 }


### PR DESCRIPTION
Allows the output to comply with the POSIX definition of a text file.
Much friendlier when working with Unix-like utilities that expect
POSIX text files.

Fixes #256 