### PR TITLE
json_pack: Enable more complete stealing of references.

### DIFF
--- a/doc/apiref.rst
+++ b/doc/apiref.rst
@@ -1564,7 +1564,10 @@ type whose address should be passed.
     Store a JSON value with no conversion to a :type:`json_t` pointer.
 
 ``O`` (any value) [json_t \*]
-    Like ``O``, but the JSON value's reference count is incremented.
+    Like ``o``, but the JSON value's reference count is incremented.
+    Storage pointers should be initialized NULL before using unpack.
+    The caller is responsible for releasing all references incremented
+    by unpack, even when an error occurs.
 
 ``[fmt]`` (array)
     Convert each item in the JSON array according to the inner format

--- a/src/value.c
+++ b/src/value.c
@@ -258,7 +258,10 @@ json_t *json_object_iter_value(void *iter)
 int json_object_iter_set_new(json_t *json, void *iter, json_t *value)
 {
     if(!json_is_object(json) || !iter || !value)
+    {
+        json_decref(value);
         return -1;
+    }
 
     hashtable_iter_set(iter, value);
     return 0;

--- a/test/suites/api/test_pack.c
+++ b/test/suites/api/test_pack.c
@@ -352,6 +352,15 @@ static void run_tests()
         fail("json_pack failed to catch NULL key");
     check_error(json_error_null_value, "NULL string argument", "<args>", 1, 2, 2);
 
+    /* NULL value followed by object still steals the object's ref */
+    value = json_incref(json_object());
+    if(json_pack_ex(&error, 0, "{s:s,s:o}", "badnull", NULL, "dontleak", value))
+        fail("json_pack failed to catch NULL value");
+    check_error(json_error_null_value, "NULL string argument", "<args>", 1, 4, 4);
+    if(value->refcount != (size_t)1)
+        fail("json_pack failed to steal reference after error.");
+    json_decref(value);
+
     /* More complicated checks for row/columns */
     if(json_pack_ex(&error, 0, "{ {}: s }", "foo"))
         fail("json_pack failed to catch object as key");


### PR DESCRIPTION
Users of the "o" format have an expectation that the object reference
will be stolen.  Any error causes the collection process to end early.
This patch causes json_pack and related functions to continue scanning
the format and parameters so all references can be stolen to prevent
leaks.  This makes no attempt to continue processing if the format
string is broken or missing.

'make check' still passes.  Ran test_pack under valgrind and verified
that the leaked reference is fixed.

Issue #135