### PR TITLE
Support object keys with known lengths, saving many strlens

### DIFF
--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -9,6 +9,7 @@
 #define HASHTABLE_H
 
 #include <stdlib.h>
+#include <stdint.h>
 #include "jansson.h"
 
 struct hashtable_list {
@@ -24,6 +25,7 @@ struct hashtable_pair {
     struct hashtable_list ordered_list;
     size_t hash;
     json_t *value;
+    uint32_t keylen;
     char key[1];
 };
 
@@ -40,6 +42,10 @@ typedef struct hashtable {
     struct hashtable_list ordered_list;
 } hashtable_t;
 
+typedef struct hashtable_key {
+    const char *key;
+    uint32_t len;
+} hashtable_key_t;
 
 #define hashtable_key_to_iter(key_) \
     (&(container_of(key_, struct hashtable_pair, key)->ordered_list))
@@ -71,6 +77,7 @@ void hashtable_close(hashtable_t *hashtable);
  *
  * @hashtable: The hashtable object
  * @key: The key
+ * @keylen: The key length
  * @serial: For addition order of keys
  * @value: The value
  *
@@ -81,27 +88,29 @@ void hashtable_close(hashtable_t *hashtable);
  *
  * Returns 0 on success, -1 on failure (out of memory).
  */
-int hashtable_set(hashtable_t *hashtable, const char *key, json_t *value);
+int hashtable_set(hashtable_t *hashtable, const char *key, size_t keylen, json_t *value);
 
 /**
  * hashtable_get - Get a value associated with a key
  *
  * @hashtable: The hashtable object
  * @key: The key
+ * @keylen: The key length
  *
  * Returns value if it is found, or NULL otherwise.
  */
-void *hashtable_get(hashtable_t *hashtable, const char *key);
+void *hashtable_get(hashtable_t *hashtable, const char *key, size_t keylen);
 
 /**
  * hashtable_del - Remove a value from the hashtable
  *
  * @hashtable: The hashtable object
  * @key: The key
+ * @keylen: The key length
  *
  * Returns 0 on success, or -1 if the key was not found.
  */
-int hashtable_del(hashtable_t *hashtable, const char *key);
+int hashtable_del(hashtable_t *hashtable, const char *key, size_t keylen);
 
 /**
  * hashtable_clear - Clear hashtable
@@ -134,11 +143,12 @@ void *hashtable_iter(hashtable_t *hashtable);
  *
  * @hashtable: The hashtable object
  * @key: The key that the iterator should point to
+ * @keylen: The key length
  *
  * Like hashtable_iter() but returns an iterator pointing to a
  * specific key.
  */
-void *hashtable_iter_at(hashtable_t *hashtable, const char *key);
+void *hashtable_iter_at(hashtable_t *hashtable, const char *key, size_t keylen);
 
 /**
  * hashtable_iter_next - Advance an iterator
@@ -156,14 +166,14 @@ void *hashtable_iter_next(hashtable_t *hashtable, void *iter);
  *
  * @iter: The iterator
  */
-void *hashtable_iter_key(void *iter);
+hashtable_key_t hashtable_iter_key(void *iter);
 
 /**
  * hashtable_iter_value - Retrieve the value pointed by an iterator
  *
  * @iter: The iterator
  */
-void *hashtable_iter_value(void *iter);
+json_t *hashtable_iter_value(void *iter);
 
 /**
  * hashtable_iter_set - Set the value pointed by an iterator

--- a/src/pack_unpack.c
+++ b/src/pack_unpack.c
@@ -504,7 +504,7 @@ static int unpack_object(scanner_t *s, json_t *root, va_list *ap)
         if(unpack(s, value, ap))
             goto out;
 
-        hashtable_set(&key_set, key, json_null());
+        hashtable_set(&key_set, key, strlen(key), json_null());
         next_token(s);
     }
 
@@ -513,7 +513,7 @@ static int unpack_object(scanner_t *s, json_t *root, va_list *ap)
 
     if(root && strict == 1) {
         /* We need to check that all non optional items have been parsed */
-        const char *key;
+        json_keyn_t kn;
         /* keys_res is 1 for uninitialized, 0 for success, -1 for error. */
         int keys_res = 1;
         strbuffer_t unrecognized_keys;
@@ -521,8 +521,8 @@ static int unpack_object(scanner_t *s, json_t *root, va_list *ap)
         long unpacked = 0;
 
         if (gotopt || json_object_size(root) != key_set.size) {
-            json_object_foreach(root, key, value) {
-                if(!hashtable_get(&key_set, key)) {
+            json_object_foreach_keyn(root, kn, value) {
+                if(!hashtable_get(&key_set, kn.key, kn.len)) {
                     unpacked++;
 
                     /* Save unrecognized keys for the error message */
@@ -533,7 +533,7 @@ static int unpack_object(scanner_t *s, json_t *root, va_list *ap)
                     }
 
                     if (!keys_res)
-                        keys_res = strbuffer_append_bytes(&unrecognized_keys, key, strlen(key));
+                        keys_res = strbuffer_append_bytes(&unrecognized_keys, kn.key, kn.len);
                 }
             }
         }


### PR DESCRIPTION
For all functions that accept or returns an object key, provide a variant that pairs it with a length.  This saves may strlens... potentially all of them, except for `json_pack` (for now!).