### PR TITLE
Deal with warnings under gcc 8.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,7 +108,14 @@ AC_DEFINE_UNQUOTED([INITIAL_HASHTABLE_ORDER], [$initial_hashtable_order],
   [Number of buckets new object hashtables contain is 2 raised to this power. E.g. 3 -> 2^3 = 8.])
 
 if test x$GCC = xyes; then
-    AM_CFLAGS="-Wall -Wextra -Wdeclaration-after-statement"
+    AC_MSG_CHECKING(for -Wno-format-truncation)
+    wnoformat_truncation="-Wno-format-truncation"
+    AS_IF([${CC} -Wno-format-truncation -Werror -S -o /dev/null -xc /dev/null > /dev/null 2>&1],
+      [AC_MSG_RESULT(yes)],
+      [AC_MSG_RESULT(no)
+      wnoformat_truncation=""])
+
+    AM_CFLAGS="-Wall -Wextra -Wdeclaration-after-statement ${wnoformat_truncation}"
 fi
 AC_SUBST([AM_CFLAGS])
 

--- a/src/error.c
+++ b/src/error.c
@@ -28,7 +28,7 @@ void jsonp_error_set_source(json_error_t *error, const char *source)
         strncpy(error->source, source, length + 1);
     else {
         size_t extra = length - JSON_ERROR_SOURCE_LENGTH + 4;
-        strncpy(error->source, "...", 3);
+        memcpy(error->source, "...", 3);
         strncpy(error->source + 3, source + extra, length - extra + 1);
     }
 }


### PR DESCRIPTION
Recent versions of gcc have introduced compiler warnings for string
operations that could be truncated.  This caused problems with -Werror.
src/error.c used strncpy to write "..." to a string, but skipped writing
the NUL terminator.  Switch this to use memcpy.  src/load.c produced
warnings from snprintf writing error strings that could be truncated.
Added code to autotools build to detect `-Wno-format-truncation', add it
to AM_CFLAGS if supported.