### PR TITLE
Implementation of JSON_DECODE_NUMBER_AS_STRING

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -254,6 +254,9 @@ static int do_dump(const json_t *json, size_t flags, int depth,
         }
 
         case JSON_STRING:
+        	if (json_string_is_number(json)) {
+        		return dump(json_string_value(json), json_string_length(json), data);
+        	}
             return dump_string(json_string_value(json), json_string_length(json), dump, data, flags);
 
         case JSON_ARRAY:

--- a/src/jansson.def
+++ b/src/jansson.def
@@ -6,12 +6,14 @@ EXPORTS
     json_sprintf
     json_vsprintf
     json_string
+    json_string_is_number
     json_stringn
     json_string_nocheck
     json_stringn_nocheck
     json_string_value
     json_string_length
     json_string_set
+    json_string_set_is_number
     json_string_setn
     json_string_set_nocheck
     json_string_setn_nocheck

--- a/src/jansson.h
+++ b/src/jansson.h
@@ -271,6 +271,8 @@ int json_array_insert(json_t *array, size_t ind, json_t *value)
 
 const char *json_string_value(const json_t *string);
 size_t json_string_length(const json_t *string);
+int json_string_is_number(const json_t *json);
+int json_string_set_is_number(const json_t *json, int bool);
 json_int_t json_integer_value(const json_t *integer);
 double json_real_value(const json_t *real);
 double json_number_value(const json_t *json);
@@ -319,6 +321,7 @@ json_t *json_deep_copy(const json_t *value) JANSSON_ATTRS(warn_unused_result);
 #define JSON_DECODE_ANY         0x4
 #define JSON_DECODE_INT_AS_REAL 0x8
 #define JSON_ALLOW_NUL          0x10
+#define JSON_DECODE_NUMBER_AS_STRING  0x20
 
 typedef size_t (*json_load_callback_t)(void *buffer, size_t buflen, void *data);
 

--- a/src/jansson_private.h
+++ b/src/jansson_private.h
@@ -48,6 +48,7 @@ typedef struct {
     json_t json;
     char *value;
     size_t length;
+    int is_number;
 } json_string_t;
 
 typedef struct {

--- a/src/load.c
+++ b/src/load.c
@@ -835,12 +835,22 @@ static json_t *parse_value(lex_t *lex, size_t flags, json_error_t *error)
         }
 
         case TOKEN_INTEGER: {
-            json = json_integer(lex->value.integer);
+            if (flags & JSON_DECODE_NUMBER_AS_STRING) {
+            	json = json_string_nocheck(strbuffer_value(&lex->saved_text));
+            	json_string_set_is_number(json, 1);
+            } else {
+            	json = json_integer(lex->value.integer);
+            }
             break;
         }
 
         case TOKEN_REAL: {
-            json = json_real(lex->value.real);
+            if (flags & JSON_DECODE_NUMBER_AS_STRING) {
+                   	json = json_string_nocheck(strbuffer_value(&lex->saved_text));
+                   	json_string_set_is_number(json, 1);
+            } else {
+            	json = json_real(lex->value.real);
+            }
             break;
         }
 

--- a/src/value.c
+++ b/src/value.c
@@ -658,6 +658,7 @@ static json_t *string_create(const char *value, size_t len, int own)
     json_init(&string->json, JSON_STRING);
     string->value = v;
     string->length = len;
+    string->is_number = 0;
 
     return &string->json;
 }
@@ -775,9 +776,30 @@ static int json_string_equal(const json_t *string1, const json_t *string2)
 static json_t *json_string_copy(const json_t *string)
 {
     json_string_t *s;
+    json_t* r;
 
     s = json_to_string(string);
-    return json_stringn_nocheck(s->value, s->length);
+    r = json_stringn_nocheck(s->value, s->length);
+    json_string_set_is_number(r, s->is_number);
+    return r;
+}
+
+int json_string_is_number(const json_t *json)
+{
+    if(!json_is_string(json))
+        return 0;
+
+    return json_to_string(json)->is_number;
+}
+
+int json_string_set_is_number(const json_t *json, int bool)
+{
+    if(!json_is_string(json))
+        return -1;
+
+    json_to_string(json)->is_number = (bool ? 1 : 0);
+
+    return 0;
 }
 
 json_t *json_vsprintf(const char *fmt, va_list ap) {

--- a/test/suites/api/test_dump.c
+++ b/test/suites/api/test_dump.c
@@ -311,6 +311,33 @@ static void embed()
     }
 }
 
+static void number_as_string()
+{
+    json_error_t error;
+	json_t* json;
+	json_t* number;
+	char* string;
+
+	json = json_object();
+	number = json_string("123.456");
+	json_string_set_is_number(number, 1);
+	json_object_set_new(json, "number", number);
+	string = json_dumps(json, 0);
+	json_decref(json);
+
+	json = json_loads(string, 0, &error);
+	free(string);
+
+	if(!json)
+		fail("json_loads returned NULL");
+	number = json_object_get(json, "number");
+	if (!number)
+		fail("json_object get number returned NULL");
+	if (!json_is_number(number))
+		fail("number is not number");
+	if (!(json_number_value(number) == 123.456))
+		fail("number is not 123.456");
+}
 static void run_tests()
 {
     encode_null();
@@ -323,4 +350,5 @@ static void run_tests()
     dumpb();
     dumpfd();
     embed();
+    number_as_string();
 }

--- a/test/suites/api/test_dump.c
+++ b/test/suites/api/test_dump.c
@@ -337,7 +337,9 @@ static void number_as_string()
 		fail("number is not number");
 	if (!(json_number_value(number) == 123.456))
 		fail("number is not 123.456");
+	json_decref(json);
 }
+
 static void run_tests()
 {
     encode_null();

--- a/test/suites/api/test_load.c
+++ b/test/suites/api/test_load.c
@@ -231,6 +231,26 @@ static void error_code()
         fail("json_loads returned incorrect error code");
 }
 
+static void number_as_string()
+{
+    json_error_t error;
+	json_t* json;
+	json_t* number;
+
+	json = json_loads("{ \"number\" : 123.456 }",
+			JSON_DECODE_NUMBER_AS_STRING, &error);
+
+	if(!json)
+		fail("json_loads returned NULL");
+	number = json_object_get(json, "number");
+	if (!number)
+		fail("json_object get number returned NULL");
+	if (!json_is_string(number))
+		fail("number is not string");
+	if (!json_string_is_number(number))
+		fail("number string is not number");
+
+}
 static void run_tests()
 {
     file_not_found();
@@ -243,4 +263,5 @@ static void run_tests()
     load_wrong_args();
     position();
     error_code();
+    number_as_string();
 }

--- a/test/suites/api/test_load.c
+++ b/test/suites/api/test_load.c
@@ -249,8 +249,9 @@ static void number_as_string()
 		fail("number is not string");
 	if (!json_string_is_number(number))
 		fail("number string is not number");
-
+	json_decref(json);
 }
+
 static void run_tests()
 {
     file_not_found();


### PR DESCRIPTION
This patch is an alternate solution for #10:

- New flag JSON_DECODE_NUMBER_AS_STRING causes json_load* to decode all numbers as strings.
- New int field in json_string_t to indicate if a string is a number. Set to true when decoding if the source field is a number. When encoding, if true json_dump* will encode the string as a number (no quotes).
- New function json_string_is_number() returns true if a string is number.
- New function json_string_set_is_number() to set the "string is a number" indicator.