### PR TITLE
Remove inappropriate jsonp_free which caused segmentation fault.

### DIFF
--- a/src/pack_unpack.c
+++ b/src/pack_unpack.c
@@ -359,9 +359,7 @@ static json_t *pack_string(scanner_t *s, va_list *ap)
         return t == '?' && !s->has_error ? json_null() : NULL;
 
     if (s->has_error) {
-        if (!ours)
-            jsonp_free(str);
-
+        /* It's impossible to reach this point if ours != 0, do not free str. */
         return NULL;
     }
 
@@ -853,6 +851,7 @@ json_t *json_vpack_ex(json_error_t *error, size_t flags,
     value = pack(&s, &ap_copy);
     va_end(ap_copy);
 
+    /* This will cover all situations where s.has_error is true */
     if(!value)
         return NULL;
 
@@ -860,10 +859,6 @@ json_t *json_vpack_ex(json_error_t *error, size_t flags,
     if(token(&s)) {
         json_decref(value);
         set_error(&s, "<format>", json_error_invalid_format, "Garbage after format string");
-        return NULL;
-    }
-    if(s.has_error) {
-        json_decref(value);
         return NULL;
     }
 

--- a/test/suites/api/test_pack.c
+++ b/test/suites/api/test_pack.c
@@ -428,6 +428,11 @@ static void run_tests()
         fail("json_pack failed to a lone +");
     check_error(json_error_invalid_format, "Unexpected format character '+'", "<format>", 1, 1, 1);
 
+    /* Empty format */
+    if(json_pack_ex(&error, 0, ""))
+        fail("json_pack failed to catch empty format string");
+    check_error(json_error_invalid_argument, "NULL or empty format string", "<format>", -1, -1, 0);
+
     /* NULL format */
     if(json_pack_ex(&error, 0, NULL))
         fail("json_pack failed to catch NULL format string");
@@ -494,4 +499,20 @@ static void run_tests()
     if(json_pack_ex(&error, 0, "{s:O}", "foo", NULL))
         fail("json_pack failed to catch nullable incref object");
     check_error(json_error_null_value, "NULL object", "<args>", 1, 4, 4);
+
+    if(json_pack_ex(&error, 0, "{s+:o}", "foo", "bar", NULL))
+        fail("json_pack failed to catch non-nullable object value");
+    check_error(json_error_null_value, "NULL object", "<args>", 1, 5, 5);
+
+    if(json_pack_ex(&error, 0, "[1s", "Hi"))
+        fail("json_pack failed to catch invalid format");
+    check_error(json_error_invalid_format, "Unexpected format character '1'", "<format>", 1, 2, 2);
+
+    if(json_pack_ex(&error, 0, "[1s+", "Hi", "ya"))
+        fail("json_pack failed to catch invalid format");
+    check_error(json_error_invalid_format, "Unexpected format character '1'", "<format>", 1, 2, 2);
+
+    if(json_pack_ex(&error, 0, "[so]", NULL, json_object()))
+        fail("json_pack failed to catch NULL value");
+    check_error(json_error_null_value, "NULL string", "<args>", 1, 2, 2);
 }


### PR DESCRIPTION
pack_string should never free str on error.  This wouldn't be a problem
except the check for `ours` was inverted.  Just remove the check for
ours since the true condition is unreachable.

json_vpack_ex also had an error check for s.has_error.  This can never
be true unless value is NULL.

Expand pack_unpack testing to cover empty format string, NULL object
value with non-null concatenated key, array containing a non-null object
after a NULL (error) string.

Fixes #444