### PR TITLE
Create JSON_RAW type, implement helpers and test coverage.

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -256,6 +256,9 @@ static int do_dump(const json_t *json, size_t flags, int depth,
         case JSON_STRING:
             return dump_string(json_string_value(json), json_string_length(json), dump, data, flags);
 
+        case JSON_RAW:
+            return dump(json_raw_value(json), json_raw_length(json), data);
+
         case JSON_ARRAY:
         {
             size_t n;

--- a/src/jansson.def
+++ b/src/jansson.def
@@ -15,6 +15,9 @@ EXPORTS
     json_string_setn
     json_string_set_nocheck
     json_string_setn_nocheck
+    json_dump_raw_new
+    json_raw_length
+    json_raw_value
     json_integer
     json_integer_value
     json_integer_set

--- a/src/jansson.h
+++ b/src/jansson.h
@@ -55,7 +55,8 @@ typedef enum {
     JSON_REAL,
     JSON_TRUE,
     JSON_FALSE,
-    JSON_NULL
+    JSON_NULL,
+    JSON_RAW
 } json_type;
 
 typedef struct json_t {
@@ -89,6 +90,7 @@ typedef long json_int_t;
 #define json_boolean_value     json_is_true
 #define json_is_boolean(json)  (json_is_true(json) || json_is_false(json))
 #define json_is_null(json)     ((json) && json_typeof(json) == JSON_NULL)
+#define json_is_raw(json)      ((json) && json_typeof(json) == JSON_RAW)
 
 /* construction, destruction, reference counting */
 
@@ -281,6 +283,17 @@ int json_string_set_nocheck(json_t *string, const char *value);
 int json_string_setn_nocheck(json_t *string, const char *value, size_t len);
 int json_integer_set(json_t *integer, json_int_t value);
 int json_real_set(json_t *real, double value);
+
+json_t *json_dump_raw_new(json_t *json, size_t flags);
+static JSON_INLINE
+json_t *json_dump_raw(json_t *json, size_t flags)
+{
+    return json_dump_raw_new(json_incref(json), flags);
+}
+
+
+const char *json_raw_value(const json_t *raw);
+size_t json_raw_length(const json_t *raw);
 
 /* pack, unpack */
 

--- a/src/jansson_private.h
+++ b/src/jansson_private.h
@@ -65,6 +65,7 @@ typedef struct {
 #define json_to_string(json_)  container_of(json_, json_string_t, json)
 #define json_to_real(json_)    container_of(json_, json_real_t, json)
 #define json_to_integer(json_) container_of(json_, json_integer_t, json)
+#define json_to_raw(json_)     container_of(json_, json_string_t, json)
 
 /* Create a string by taking ownership of an existing buffer */
 json_t *jsonp_stringn_nocheck_own(const char *value, size_t len);

--- a/src/value.c
+++ b/src/value.c
@@ -634,8 +634,9 @@ static json_t *json_array_deep_copy(const json_t *array)
 
 /*** string ***/
 
-static json_t *string_create(const char *value, size_t len, int own)
+static json_t *string_create(const char *value, size_t len, int own, json_type type)
 {
+    /* This function is used for JSON_STRING and JSON_RAW. */
     char *v;
     json_string_t *string;
 
@@ -655,7 +656,7 @@ static json_t *string_create(const char *value, size_t len, int own)
         jsonp_free(v);
         return NULL;
     }
-    json_init(&string->json, JSON_STRING);
+    json_init(&string->json, type);
     string->value = v;
     string->length = len;
 
@@ -667,18 +668,18 @@ json_t *json_string_nocheck(const char *value)
     if(!value)
         return NULL;
 
-    return string_create(value, strlen(value), 0);
+    return string_create(value, strlen(value), 0, JSON_STRING);
 }
 
 json_t *json_stringn_nocheck(const char *value, size_t len)
 {
-    return string_create(value, len, 0);
+    return string_create(value, len, 0, JSON_STRING);
 }
 
 /* this is private; "steal" is not a public API concept */
 json_t *jsonp_stringn_nocheck_own(const char *value, size_t len)
 {
-    return string_create(value, len, 1);
+    return string_create(value, len, 1, JSON_STRING);
 }
 
 json_t *json_string(const char *value)
@@ -759,12 +760,14 @@ int json_string_setn(json_t *json, const char *value, size_t len)
 
 static void json_delete_string(json_string_t *string)
 {
+    /* This function is used by JSON_STRING and JSON_RAW */
     jsonp_free(string->value);
     jsonp_free(string);
 }
 
 static int json_string_equal(const json_t *string1, const json_t *string2)
 {
+    /* This function is used for JSON_STRING and JSON_RAW. */
     json_string_t *s1, *s2;
 
     s1 = json_to_string(string1);
@@ -957,6 +960,43 @@ json_t *json_null(void)
 }
 
 
+/*** raw ***/
+json_t *json_dump_raw_new(json_t *json, size_t flags)
+{
+    char *raw = json_dumps(json, JSON_ENCODE_ANY | flags);
+
+    json_decref(json);
+
+    if (!raw) {
+        return NULL;
+    }
+
+    return string_create(raw, strlen(raw), 1, JSON_RAW);
+}
+
+const char *json_raw_value(const json_t *json)
+{
+    if(!json_is_raw(json))
+        return NULL;
+
+    return json_to_raw(json)->value;
+}
+
+size_t json_raw_length(const json_t *json)
+{
+    if(!json_is_raw(json))
+        return 0;
+
+    return json_to_raw(json)->length;
+}
+
+static json_t *json_raw_copy(const json_t *raw)
+{
+    json_string_t *s = json_to_raw(raw);
+
+    return string_create(s->value, s->length, 0, JSON_RAW);
+}
+
 /*** deletion ***/
 
 void json_delete(json_t *json)
@@ -972,6 +1012,7 @@ void json_delete(json_t *json)
             json_delete_array(json_to_array(json));
             break;
         case JSON_STRING:
+        case JSON_RAW:
             json_delete_string(json_to_string(json));
             break;
         case JSON_INTEGER:
@@ -1013,6 +1054,8 @@ int json_equal(const json_t *json1, const json_t *json2)
             return json_integer_equal(json1, json2);
         case JSON_REAL:
             return json_real_equal(json1, json2);
+        case JSON_RAW:
+            return json_string_equal(json1, json2);
         default:
             return 0;
     }
@@ -1041,6 +1084,8 @@ json_t *json_copy(json_t *json)
         case JSON_FALSE:
         case JSON_NULL:
             return json;
+        case JSON_RAW:
+            return json_raw_copy(json);
         default:
             return NULL;
     }
@@ -1068,6 +1113,8 @@ json_t *json_deep_copy(const json_t *json)
         case JSON_FALSE:
         case JSON_NULL:
             return (json_t *)json;
+        case JSON_RAW:
+            return json_raw_copy(json);
         default:
             return NULL;
     }

--- a/test/suites/api/test_chaos.c
+++ b/test/suites/api/test_chaos.c
@@ -9,7 +9,7 @@
 
 static int chaos_pos = 0;
 static int chaos_fail = 0;
-#define CHAOS_MAX_FAILURE 100
+#define CHAOS_MAX_FAILURE 200
 
 void *chaos_malloc(size_t size)
 {
@@ -160,6 +160,7 @@ static void test_chaos()
 
     chaos_loop(json_array_extend(arr1, arr2),,);
     chaos_loop(json_string_set_nocheck(txt, "test"),,);
+    chaos_loop_new_value(json, json_dump_raw(obj, 0));
 
     json_set_alloc_funcs(orig_malloc, orig_free);
     json_decref(obj);

--- a/test/suites/api/test_copy.c
+++ b/test/suites/api/test_copy.c
@@ -56,6 +56,22 @@ static void test_copy_simple(void)
     json_decref(value);
     json_decref(copy);
 
+    /* raw */
+    value = json_dump_raw(json_null(), JSON_DECODE_ANY);
+    if(!value)
+        fail("unable to create a raw");
+    copy = json_copy(value);
+    if(!copy)
+        fail("unable to copy a raw");
+    if(copy == value)
+        fail("copying a raw doesn't copy");
+    if(!json_equal(copy, value))
+        fail("copying a raw produces an inequal copy");
+    if(value->refcount != 1 || copy->refcount != 1)
+        fail("invalid refcounts");
+    json_decref(value);
+    json_decref(copy);
+
     /* integer */
     value = json_integer(543);
     if(!value)
@@ -131,6 +147,22 @@ static void test_deep_copy_simple(void)
         fail("deep copying a string doesn't copy");
     if(!json_equal(copy, value))
         fail("deep copying a string produces an inequal copy");
+    if(value->refcount != 1 || copy->refcount != 1)
+        fail("invalid refcounts");
+    json_decref(value);
+    json_decref(copy);
+
+    /* raw */
+    value = json_dump_raw(json_null(), JSON_DECODE_ANY);
+    if(!value)
+        fail("unable to create a raw");
+    copy = json_deep_copy(value);
+    if(!copy)
+        fail("unable to deep copy a raw");
+    if(copy == value)
+        fail("deep copying a raw doesn't copy");
+    if(!json_equal(copy, value))
+        fail("deep copying a raw produces an inequal copy");
     if(value->refcount != 1 || copy->refcount != 1)
         fail("invalid refcounts");
     json_decref(value);

--- a/test/suites/api/test_dump.c
+++ b/test/suites/api/test_dump.c
@@ -154,6 +154,22 @@ static void encode_other_than_array_or_object()
     free(result);
     json_decref(json);
 
+    json = json_dump_raw_new(json_array(), 0);
+    if(json_dumps(json, 0) != NULL)
+        fail("json_dumps encoded a raw!");
+    if(json_dumpf(json, NULL, 0) == 0)
+        fail("json_dumpf encoded a raw!");
+    if(json_dumpfd(json, -1, 0) == 0)
+        fail("json_dumpfd encoded a raw!");
+
+    result = json_dumps(json, JSON_ENCODE_ANY);
+    if(!result || strcmp(result, "[]") != 0)
+        fail("json_dumps failed to encode a raw with JSON_ENCODE_ANY");
+
+    free(result);
+    json_decref(json);
+
+
     json = json_integer(42);
     if(json_dumps(json, 0) != NULL)
         fail("json_dumps encoded an integer!");

--- a/test/suites/api/test_simple.c
+++ b/test/suites/api/test_simple.c
@@ -11,10 +11,10 @@
 
 static void test_bad_args(void)
 {
-    json_t *num = json_integer(1);
+    json_t *raw = json_dump_raw_new(json_object(), 0);
     json_t *txt = json_string("test");
 
-    if (!num || !txt)
+    if (!raw || !txt)
         fail("failed to allocate test objects");
 
     if(json_string_nocheck(NULL) != NULL)
@@ -28,17 +28,17 @@ static void test_bad_args(void)
 
     if(json_string_length(NULL) != 0)
         fail("json_string_length with non-string argument did not return 0");
-    if(json_string_length(num) != 0)
+    if(json_string_length(raw) != 0)
         fail("json_string_length with non-string argument did not return 0");
 
     if(json_string_value(NULL) != NULL)
         fail("json_string_value with non-string argument did not return NULL");
-    if(json_string_value(num) != NULL)
+    if(json_string_value(raw) != NULL)
         fail("json_string_value with non-string argument did not return NULL");
 
     if(!json_string_setn_nocheck(NULL, "", 0))
         fail("json_string_setn with non-string argument did not return error");
-    if(!json_string_setn_nocheck(num, "", 0))
+    if(!json_string_setn_nocheck(raw, "", 0))
         fail("json_string_setn with non-string argument did not return error");
     if(!json_string_setn_nocheck(txt, NULL, 0))
         fail("json_string_setn_nocheck with NULL value did not return error");
@@ -50,12 +50,24 @@ static void test_bad_args(void)
     if(!json_string_setn(txt, NULL, 0))
         fail("json_string_setn with NULL value did not return error");
 
-    if(num->refcount != 1)
-        fail("unexpected reference count for num");
+
+    if(json_raw_length(NULL) != 0)
+        fail("json_raw_length with NULL argument did not return 0");
+    if(json_raw_length(txt) != 0)
+        fail("json_raw_length with non-raw argument did not return 0");
+
+    if(json_raw_value(NULL) != NULL)
+        fail("json_raw_value with NULL argument did not return NULL");
+    if(json_raw_value(txt) != NULL)
+        fail("json_raw_value with non-raw argument did not return NULL");
+
+
+    if(raw->refcount != 1)
+        fail("unexpected reference count for raw");
     if(txt->refcount != 1)
         fail("unexpected reference count for txt");
 
-    json_decref(num);
+    json_decref(raw);
     json_decref(txt);
 }
 
@@ -115,6 +127,9 @@ static void run_tests()
 
     if(json_is_null(value))
         fail("json_is_null failed");
+
+    if(json_is_raw(value))
+        fail("json_is_raw failed");
 
     json_decref(value);
 
@@ -191,6 +206,17 @@ static void run_tests()
         fail("invalid string value");
     if (json_string_length(value) != 3)
         fail("invalid string length");
+
+    json_decref(value);
+
+
+    value = json_dump_raw_new(json_object(), 0);
+    if(!value)
+        fail("json_raw failed");
+    if(strcmp(json_raw_value(value), "{}"))
+        fail("invalid raw value");
+    if (json_raw_length(value) != 2)
+        fail("invalid raw length");
 
     json_decref(value);
 


### PR DESCRIPTION
Related to issue #10
---
This is just an initial implementation of the json_raw type.  This patch does not include any changes to the parser, the idea is that one of the patches which allow numbers to not be parsed would be updated to store values in json_raw instead of using json_string with a flag.  The main goal is to avoid expanding the memory footprint of json strings which are very widely used.

apiref.rst needs updating to document the new functions.  I'll do that once it's decided that we want to proceed with this change.