### PR TITLE
jansson 2.12

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,43 @@
+Version 2.12
+
+Released 2018-11-25
+
+* Bug fixes:
+
+  - Fix error message in `json_pack()` for NULL object (#409).
+
+  - Avoid invalid memory read in `json_pack()` (#421).
+
+  - Call va_end after va_copy in `json_vsprintf()` (#427).
+
+  - Improve handling of formats with '?' and '*' in `json_pack()` (#438).
+
+  - Remove inappropriate `jsonp_free()` which caused segmentation fault in
+    error handling (#444).
+
+* Build:
+
+  - Add function attributes for GCC and CLANG to provide warnings on improper
+    use of jansson routines (#404).
+
+  - Many CMake fixes (#408, #412, #415).
+
+  - Enable -Bsymbolic-functions linker flag whenever possible.
+
+  - Resolve various compiler warnings (#423, #430, #435, #436).
+
+  - Fix code coverage ignored paths (#439).
+
+* Other:
+
+  - Test coverage improvements (#398, #400).
+
+  - Add VS 2017 to appveyor, update Visual Studio documentation (#417).
+
+  - Update copyright for 2018 (#424).
+
+  - Update install instructions in README (#401).
+
 Version 2.11
 ============
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,10 +85,10 @@ endif()
 # set (JANSSON_VERSION "2.3.1")
 # set (JANSSON_SOVERSION 2)
 
-set(JANSSON_DISPLAY_VERSION "2.11")
+set(JANSSON_DISPLAY_VERSION "2.12")
 
 # This is what is required to match the same numbers as automake's
-set(JANSSON_VERSION "4.11.0")
+set(JANSSON_VERSION "4.11.1")
 set(JANSSON_SOVERSION 4)
 
 # for CheckFunctionKeywords

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.60])
-AC_INIT([jansson], [2.11], [petri@digip.org])
+AC_INIT([jansson], [2.12], [petri@digip.org])
 
 AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([1.10 foreign])

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,7 +48,7 @@ copyright = u'2009-2016, Petri Lehtinen'
 # built documents.
 #
 # The short X.Y version.
-version = '2.11'
+version = '2.12'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,5 +24,5 @@ libjansson_la_SOURCES = \
 libjansson_la_LDFLAGS = \
 	-no-undefined \
 	-export-symbols-regex '^json_' \
-	-version-info 15:0:11 \
+	-version-info 15:1:11 \
 	@JSON_BSYMBOLIC_LDFLAGS@

--- a/src/jansson.h
+++ b/src/jansson.h
@@ -21,11 +21,11 @@ extern "C" {
 /* version */
 
 #define JANSSON_MAJOR_VERSION  2
-#define JANSSON_MINOR_VERSION  11
+#define JANSSON_MINOR_VERSION  12
 #define JANSSON_MICRO_VERSION  0
 
 /* Micro version is omitted if it's 0 */
-#define JANSSON_VERSION  "2.11"
+#define JANSSON_VERSION  "2.12"
 
 /* Version as a 3-byte hex number, e.g. 0x010201 == 1.2.1. Use this
    for numeric comparisons, e.g. #if JANSSON_VERSION_HEX >= ... */


### PR DESCRIPTION
This is a bit of a grey area for 2.12.0 vs 2.11.1.  I decided to go for 2.12 since this includes the addition of function attributes which can be viewed as API changes (compile warnings added in certain situations).  The so-version only gets a revision bump as no ABI changes are included - a program compiled against 2.12 will run on a system where 2.11 is installed.  The primary reason I want to do the release is to provide a version with #444 as this fixes a regression in 2.11.  In theory I could cherry-pick that to create a v2.11.1 but I don't see any reason to hold back the other changes.

I've completed all steps from https://github.com/akheron/jansson/wiki/Releasing up to the commit.