### PR TITLE
Add json_object_update_recursive()

### DIFF
--- a/doc/apiref.rst
+++ b/doc/apiref.rst
@@ -689,6 +689,12 @@ allowed in object keys.
 
    .. versionadded:: 2.3
 
+.. function:: int json_object_update_recursive(json_t *object, json_t *other)
+
+   Like :func:`json_object_update()`, but object values in *other* are
+   recursively merged with the corresponding values in *object* if they are also
+   objects, instead of overwriting them. Returns 0 on success or -1 on error.
+
 .. function:: json_object_foreach(object, key, value)
 
    Iterate over every key-value pair of ``object``, running the block

--- a/src/jansson.def
+++ b/src/jansson.def
@@ -41,6 +41,7 @@ EXPORTS
     json_object_update
     json_object_update_existing
     json_object_update_missing
+    json_object_update_recursive
     json_object_iter
     json_object_iter_at
     json_object_iter_next

--- a/src/jansson.h
+++ b/src/jansson.h
@@ -199,6 +199,7 @@ int json_object_clear(json_t *object);
 int json_object_update(json_t *object, json_t *other);
 int json_object_update_existing(json_t *object, json_t *other);
 int json_object_update_missing(json_t *object, json_t *other);
+int json_object_update_recursive(json_t *object, json_t *other);
 void *json_object_iter(json_t *object);
 void *json_object_iter_at(json_t *object, const char *key);
 void *json_object_key_to_iter(const char *key);

--- a/src/value.c
+++ b/src/value.c
@@ -204,6 +204,26 @@ int json_object_update_missing(json_t *object, json_t *other)
     return 0;
 }
 
+int json_object_update_recursive(json_t *object, json_t *other)
+{
+    const char *key;
+    json_t *value;
+
+    if(!json_is_object(object) || !json_is_object(other))
+        return -1;
+
+    json_object_foreach(other, key, value) {
+        json_t *v = json_object_get(object, key);
+
+        if(json_is_object(v) && json_is_object(value))
+            json_object_update_recursive(v, value);
+        else
+            json_object_set_nocheck(object, key, value);
+    }
+
+    return 0;
+}
+
 void *json_object_iter(json_t *json)
 {
     json_object_t *object;


### PR DESCRIPTION
Support merging values nested within objects. For instance, merging:

```json
    {
	"foo": 1,
	"bar": {
	    "baz": 2
	}
    }
```

with

```json
    {
	"bar": {
	    "baz": 3
	}
    }
```

results in

```json
    {
	"foo": 1,
	"bar": {
	    "baz": 3
	}
    }
```

instead of overwriting the value for the bar key.