### PR TITLE
Add location information to decoded JSON objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,6 +509,7 @@ if (NOT JANSSON_WITHOUT_TESTS)
          test_load
          test_loadb
          test_load_callback
+         test_location
          test_number
          test_object
          test_pack

--- a/doc/apiref.rst
+++ b/doc/apiref.rst
@@ -1257,6 +1257,12 @@ macros can be ORed together to obtain *flags*.
 
    .. versionadded:: 2.6
 
+``JSON_STORE_LOCATION``
+   Add location information to decoded :type:`json_t` objects. See
+   :ref:`apiref-location-information` for details.
+
+   .. versionadded:: 2.13
+
 Each function also takes an optional :type:`json_error_t` parameter
 that is filled with error information if decoding fails. It's also
 updated on success; the number of bytes of input read is written to
@@ -1879,3 +1885,36 @@ memory, see
 http://www.dwheeler.com/secure-programs/Secure-Programs-HOWTO/protect-secrets.html.
 The page also explains the :func:`guaranteed_memset()` function used
 in the example and gives a sample implementation for it.
+
+.. _apiref-location-information:
+
+Location Information
+====================
+
+Jansson supports storing decoded objects' locations in input for better
+reporting of semantic errors in applications. Since this comes with a certain
+overhead, location information is stored only if ``JSON_STORE_LOCATION`` flag
+was specified during decoding.
+
+.. function:: int json_get_location(json_t *json, int *line, int *column, int *position, int *length);
+
+   Retrieve location of *json* writing it to memory locations pointed to by
+   *line*, *column*, *position* and *length* if not *NULL*. Returns 0 on success
+   or -1 if no location information is available for *json*.
+
+``line``
+   The line number on which the object occurred.
+
+``column``
+   The column on which the object occurred. Note that this is the *character
+   column*, not the byte column, i.e. a multibyte UTF-8 character counts as one
+   column.
+
+``position``
+   The position in bytes from the start of the input. This is useful for
+   debugging Unicode encoding problems.
+
+``length``
+   The length of the object in bytes. For arrays and objects, length is always
+   1. For all other types, the value resembles the actual length as it appears
+   in input. Note that for strings, this includes the quotes.

--- a/src/jansson.def
+++ b/src/jansson.def
@@ -74,4 +74,5 @@ EXPORTS
     json_get_alloc_funcs
     jansson_version_str
     jansson_version_cmp
+    json_get_location
 

--- a/src/jansson.h
+++ b/src/jansson.h
@@ -319,6 +319,7 @@ json_t *json_deep_copy(const json_t *value) JANSSON_ATTRS(warn_unused_result);
 #define JSON_DECODE_ANY         0x4
 #define JSON_DECODE_INT_AS_REAL 0x8
 #define JSON_ALLOW_NUL          0x10
+#define JSON_STORE_LOCATION     0x20
 
 typedef size_t (*json_load_callback_t)(void *buffer, size_t buflen, void *data);
 
@@ -364,6 +365,10 @@ void json_get_alloc_funcs(json_malloc_t *malloc_fn, json_free_t *free_fn);
 
 const char *jansson_version_str(void);
 int jansson_version_cmp(int major, int minor, int micro);
+
+/* location information */
+
+int json_get_location(json_t *json, int *line, int *column, int *position, int *length);
 
 #ifdef __cplusplus
 }

--- a/src/jansson_private.h
+++ b/src/jansson_private.h
@@ -33,8 +33,16 @@
 #endif
 
 typedef struct {
+    int line;
+    int column;
+    int position;
+    int length;
+} json_location_t;
+
+typedef struct {
     json_t json;
     hashtable_t hashtable;
+    json_location_t *location;
 } json_object_t;
 
 typedef struct {
@@ -42,29 +50,39 @@ typedef struct {
     size_t size;
     size_t entries;
     json_t **table;
+    json_location_t *location;
 } json_array_t;
 
 typedef struct {
     json_t json;
     char *value;
     size_t length;
+    json_location_t *location;
 } json_string_t;
 
 typedef struct {
     json_t json;
     double value;
+    json_location_t *location;
 } json_real_t;
 
 typedef struct {
     json_t json;
     json_int_t value;
+    json_location_t *location;
 } json_integer_t;
+
+typedef struct {
+    json_t json;
+    json_location_t *location;
+} json_simple_t;
 
 #define json_to_object(json_)  container_of(json_, json_object_t, json)
 #define json_to_array(json_)   container_of(json_, json_array_t, json)
 #define json_to_string(json_)  container_of(json_, json_string_t, json)
 #define json_to_real(json_)    container_of(json_, json_real_t, json)
 #define json_to_integer(json_) container_of(json_, json_integer_t, json)
+#define json_to_simple(json_)  container_of(json_, json_simple_t, json)
 
 /* Create a string by taking ownership of an existing buffer */
 json_t *jsonp_stringn_nocheck_own(const char *value, size_t len);
@@ -90,6 +108,9 @@ char *jsonp_strndup(const char *str, size_t length) JANSSON_ATTRS(warn_unused_re
 char *jsonp_strdup(const char *str) JANSSON_ATTRS(warn_unused_result);
 char *jsonp_strndup(const char *str, size_t len) JANSSON_ATTRS(warn_unused_result);
 
+/* Helpers for location information */
+json_t *jsonp_simple(json_t *json, size_t flags);
+json_location_t **jsonp_to_location_pptr(json_t *json);
 
 /* Windows compatibility */
 #if defined(_WIN32) || defined(WIN32)

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -10,6 +10,7 @@ suites/api/test_equal
 suites/api/test_load
 suites/api/test_load_callback
 suites/api/test_loadb
+suites/api/test_location
 suites/api/test_memory_funcs
 suites/api/test_number
 suites/api/test_object

--- a/test/suites/api/Makefile.am
+++ b/test/suites/api/Makefile.am
@@ -10,6 +10,7 @@ check_PROGRAMS = \
 	test_load \
 	test_loadb \
 	test_load_callback \
+	test_location \
 	test_memory_funcs \
 	test_number \
 	test_object \
@@ -26,6 +27,7 @@ test_dump_SOURCES = test_dump.c util.h
 test_dump_callback_SOURCES = test_dump_callback.c util.h
 test_load_SOURCES = test_load.c util.h
 test_loadb_SOURCES = test_loadb.c util.h
+test_location_SOURCES = test_location.c util.h
 test_memory_funcs_SOURCES = test_memory_funcs.c util.h
 test_number_SOURCES = test_number.c util.h
 test_object_SOURCES = test_object.c util.h

--- a/test/suites/api/test_location.c
+++ b/test/suites/api/test_location.c
@@ -1,0 +1,162 @@
+#include <jansson.h>
+#include <string.h>
+#include <stdarg.h>
+#include "util.h"
+
+
+#define INPUT "{ \"testkey\": [\"testvalue1\", \"testvalue2\"] }"
+#define MULTILINE_INPUT						\
+"{\n"								\
+"	\"root key 1\": \"root key 1 value 1\",\n"		\
+"	\"root key 2\": [\n"					\
+"		\"root key 2 array value 1\",\n"		\
+"		\"root key 2 array value 2\"\n"			\
+"	],\n"							\
+"	\"root key 3\": [ true, false ],\n"			\
+"	\"root key 4\": null,\n"				\
+"	\"root key 5\": {\n"					\
+"		\"root key 5 object key 1\": 23,\n"		\
+"		\"root key 5 object key 2\": 3.1415926536\n"	\
+"	},\n"							\
+"	\"root key emoji\": \"\\uD83D\\uDE02\"\n"		\
+"}\n"
+
+#define OUTPUT							\
+"object at line 1 column 1 length 1\n"				\
+"object key \"testkey\" value at line 1 column 14 length 1\n"	\
+"array at line 1 column 14 length 1\n"				\
+"array item 0 at line 1 column 15 length 12\n"			\
+"string: \"testvalue1\" at line 1 column 15 length 12\n"	\
+"array item 1 at line 1 column 29 length 12\n"			\
+"string: \"testvalue2\" at line 1 column 29 length 12\n"
+
+#define MULTILINE_OUTPUT							\
+"object at line 1 column 1 length 1\n"						\
+"object key \"root key 1\" value at line 2 column 16 length 20\n"		\
+"string: \"root key 1 value 1\" at line 2 column 16 length 20\n"		\
+"object key \"root key 2\" value at line 3 column 16 length 1\n"		\
+"array at line 3 column 16 length 1\n"						\
+"array item 0 at line 4 column 3 length 26\n"					\
+"string: \"root key 2 array value 1\" at line 4 column 3 length 26\n"		\
+"array item 1 at line 5 column 3 length 26\n"					\
+"string: \"root key 2 array value 2\" at line 5 column 3 length 26\n"		\
+"object key \"root key 3\" value at line 7 column 16 length 1\n"		\
+"array at line 7 column 16 length 1\n"						\
+"array item 0 at line 7 column 18 length 4\n"					\
+"true at line 7 column 18 length 4\n"						\
+"array item 1 at line 7 column 24 length 5\n"					\
+"false at line 7 column 24 length 5\n"						\
+"object key \"root key 4\" value at line 8 column 16 length 4\n"		\
+"null at line 8 column 16 length 4\n"						\
+"object key \"root key 5\" value at line 9 column 16 length 1\n"		\
+"object at line 9 column 16 length 1\n"						\
+"object key \"root key 5 object key 1\" value at line 10 column 30 length 2\n"	\
+"integer: 23 at line 10 column 30 length 2\n"					\
+"object key \"root key 5 object key 2\" value at line 11 column 30 length 12\n"	\
+"real: 3.141593 at line 11 column 30 length 12\n"				\
+"object key \"root key emoji\" value at line 13 column 20 length 14\n"		\
+"string: \"😂\" at line 13 column 20 length 14\n"
+
+static void print_location(char *outbuf, ssize_t *outbufspace,
+			   json_t *root, const char *fmt, ...)
+{
+	va_list ap;
+	char buf[1024];
+	int line, column, length;
+
+	if (*outbufspace <= 0)
+		return;
+
+	if (json_get_location(root, &line, &column, NULL, &length))
+		return;
+
+	va_start(ap, fmt);
+	vsnprintf(buf, 1024, fmt, ap);
+	va_end(ap);
+	strncat(outbuf, buf, *outbufspace);
+	*outbufspace -= strlen(buf);
+
+	if (*outbufspace <= 0)
+		return;
+
+	sprintf(buf, " at line %d column %d length %d\n", line, column, length);
+	strncat(outbuf, buf, *outbufspace);
+	*outbufspace -= strlen(buf);
+}
+
+static void parse(char *outbuf, ssize_t *outbufspace, json_t *root)
+{
+	unsigned int index;
+	const char *key;
+	json_t *tmp;
+
+	switch(json_typeof(root)) {
+	case JSON_OBJECT:
+		print_location(outbuf, outbufspace, root, "object");
+		json_object_foreach(root, key, tmp) {
+			print_location(outbuf, outbufspace, tmp,
+				       "object key \"%s\" value", key);
+			parse(outbuf, outbufspace, tmp);
+		}
+		break;
+	case JSON_ARRAY:
+		print_location(outbuf, outbufspace, root, "array");
+		json_array_foreach(root, index, tmp) {
+			print_location(outbuf, outbufspace, tmp,
+				       "array item %u", index);
+			parse(outbuf, outbufspace, tmp);
+		}
+		break;
+	case JSON_STRING:
+		print_location(outbuf, outbufspace, root,
+			       "string: \"%s\"", json_string_value(root));
+		break;
+	case JSON_INTEGER:
+		print_location(outbuf, outbufspace, root,
+			       "integer: %" JSON_INTEGER_FORMAT,
+			       json_integer_value(root));
+		break;
+	case JSON_REAL:
+		print_location(outbuf, outbufspace, root,
+			       "real: %lf", json_real_value(root));
+		break;
+	case JSON_TRUE:
+		print_location(outbuf, outbufspace, root, "true");
+		break;
+	case JSON_FALSE:
+		print_location(outbuf, outbufspace, root, "false");
+		break;
+	case JSON_NULL:
+		print_location(outbuf, outbufspace, root, "null");
+		break;
+	default:
+		print_location(outbuf, outbufspace, root, "unknown");
+	}
+}
+
+static void run_test(const char *input, const char *output, int store)
+{
+	ssize_t bufspace;
+	char buf[8192];
+
+	json_t *root = json_loads(input, store ? JSON_STORE_LOCATION : 0, NULL);
+	if (!root)
+		fail("loading input failed");
+	*buf = '\0';
+	bufspace = sizeof(buf) - 1;
+	parse(buf, &bufspace, root);
+	json_decref(root);
+
+	if (store && strcmp(buf, output))
+		fail_args("output doesn't match:\nexpect:\n%s\ngot:\n%s\n", output, buf);
+	else if (!store && strlen(buf))
+		fail("got output where none should be\n");
+}
+
+static void run_tests(void)
+{
+	run_test(INPUT, OUTPUT, 0);
+	run_test(MULTILINE_INPUT, MULTILINE_OUTPUT, 0);
+	run_test(INPUT, OUTPUT, 1);
+	run_test(MULTILINE_INPUT, MULTILINE_OUTPUT, 1);
+}

--- a/test/suites/api/util.h
+++ b/test/suites/api/util.h
@@ -29,6 +29,13 @@
         exit(1);                                                 \
     } while(0)
 
+#define fail_args(msg, ...)                                      \
+    do {                                                         \
+        failhdr;                                                 \
+        fprintf(stderr, msg "\n", __VA_ARGS__);                  \
+        exit(1);                                                 \
+    } while(0)
+
 /* Assumes json_error_t error */
 #define check_errors(code_, texts_, num_, source_,                      \
     line_, column_, position_)                                          \


### PR DESCRIPTION
Aid users in printing semantic errors in JSON input by allowing them to
point to syntactically valid JSON objects causing the semantic error.