### PR TITLE
Fixed the compiler error related to need to include standard integer …

### DIFF
--- a/src/jansson.h
+++ b/src/jansson.h
@@ -8,6 +8,7 @@
 #ifndef JANSSON_H
 #define JANSSON_H
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>  /* for size_t */
 #include <stdarg.h>


### PR DESCRIPTION
…library, just like in bos-jansson fork

Fixed the compiler error related to need to include standard integer library, just like in bos-jansson fork: https://github.com/melt7777/bos-jansson/commit/7a2732e18083201cfb5915e8ffaa7fceb750837a

10:57:40 /bin/bash ../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..    -Wall -Wextra -Wdeclaration-after-statement -Wshadow -Wno-format-truncation -g -O2 -MT bos_deserializer.lo -MD -MP -MF .deps/bos_deserializer.Tpo -c -o bos_deserializer.lo bos_deserializer.c
10:57:41 libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -Wall -Wextra -Wdeclaration-after-statement -Wshadow -Wno-format-truncation -g -O2 -MT bos_deserializer.lo -MD -MP -MF .deps/bos_deserializer.Tpo -c bos_deserializer.c  -fPIC -DPIC -o .libs/bos_deserializer.o
10:57:41 In file included from jansson_private.h:13:0,
10:57:41                  from bos_deserializer.c:12:
10:57:41 bosjansson.h:69:5: error: unknown type name ‘uint32_t’
10:57:41      uint32_t size;
10:57:41      ^~~~~~~~
10:57:41 bos_deserializer.c: In function ‘validate_value’:
10:57:41 bos_deserializer.c:443:5: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
10:57:41      uint8_t data_type;
10:57:41      ^~~~~~~
10:57:41 bos_deserializer.c: In function ‘bos_validate’:
10:57:41 bos_deserializer.c:501:5: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
10:57:41      buffer_t buffer;
10:57:41      ^~~~~~~~
10:57:42 Makefile:473: recipe for target 'bos_deserializer.lo' failed
10:57:42 make[5]: *** [bos_deserializer.lo] Error 1
10:57:42 make[5]: Leaving directory '/root/jenkins/workspace/miners/miner-build-sgminer-fancyix/label/pimp=2.8/submodules/jansson/src'
10:57:42 Makefile:454: recipe for target 'all-recursive' failed
10:57:42 make[4]: *** [all-recursive] Error 1
10:57:42 make[4]: Leaving directory '/root/jenkins/workspace/miners/miner-build-sgminer-fancyix/label/pimp=2.8/submodules/jansson'
10:57:42 Makefile:363: recipe for target 'all' failed
10:57:42 make[3]: *** [all] Error 2
10:57:42 make[3]: Leaving directory '/root/jenkins/workspace/miners/miner-build-sgminer-fancyix/label/pimp=2.8/submodules/jansson'
10:57:42 Makefile:519: recipe for target 'all-recursive' failed
10:57:42 make[2]: *** [all-recursive] Error 1
10:57:42 make[2]: Leaving directory '/root/jenkins/workspace/miners/miner-build-sgminer-fancyix/label/pimp=2.8/submodules'
10:57:42 Makefile:2298: recipe for target 'all-recursive' failed
10:57:42 make[1]: *** [all-recursive] Error 1
10:57:42 make[1]: Leaving directory '/root/jenkins/workspace/miners/miner-build-sgminer-fancyix/label/pimp=2.8'
10:57:42 Makefile:739: recipe for target 'all' failed
10:57:42 make: *** [all] Error 2