### PR TITLE
Make CMAKE_DEBUG_POSTFIX truly optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ set(JANSSON_TEMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/tmp)
 # Give the debug version a different postfix for windows,
 # so both the debug and release version can be built in the
 # same build-tree on Windows (MSVC).
-if (WIN32 AND NOT CMAKE_DEBUG_POSTFIX)
+if (WIN32 AND NOT DEFINED CMAKE_DEBUG_POSTFIX)
    set(CMAKE_DEBUG_POSTFIX "_d")
 endif()
 


### PR DESCRIPTION
The missing piece to fix  #385

Add DEFINED to the conditional to allow the user to set CMAKE_DEBUG_POSTFIX to blank which will disable the _d suffix on Windows builds. Othwerise, the default jansson cmake behavior is unchanged.