### PR TITLE
Fix LNK4099 warnings when linking jansson as a static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,12 @@ if (MSVC)
       set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
       set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
    endif()
+
+   # Embed PDBs to prevent annoying LNK4099 warning if building static lib
+   if (NOT JANSSON_BUILD_SHARED_LIBS)
+      set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} /Z7")
+      set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /Z7")
+   endif()
 endif()
 
 message("C compiler: ${CMAKE_C_COMPILER_ID}")


### PR DESCRIPTION
By default, jansson builds as static lib with /Zi in Debug configuration on Windows. When linking static libs on Windows you can get LNK4099 linker warnings if the static lib was built with external PDB (/Zi). To fix this, you need to disable debug symbols (release mode) or change the debug saymbol format to "C7 Compatible (/Z7)". This change fixes the MSVC compiler flags for Debug and RelWithDebInfo cmake configurations.