### PR TITLE
Fix warning in src/load.c

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -89,7 +89,7 @@ static void error_set(json_error_t *error, const lex_t *lex,
 {
     va_list ap;
     char msg_text[JSON_ERROR_TEXT_LENGTH];
-    char msg_with_context[JSON_ERROR_TEXT_LENGTH];
+    char msg_with_context[JSON_ERROR_TEXT_LENGTH + 20];
 
     int line = -1, col = -1;
     size_t pos = 0;
@@ -114,9 +114,8 @@ static void error_set(json_error_t *error, const lex_t *lex,
         if(saved_text && saved_text[0])
         {
             if(lex->saved_text.length <= 20) {
-                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH,
+                snprintf(msg_with_context, sizeof(msg_with_context),
                          "%s near '%s'", msg_text, saved_text);
-                msg_with_context[JSON_ERROR_TEXT_LENGTH - 1] = '\0';
                 result = msg_with_context;
             }
         }
@@ -131,9 +130,8 @@ static void error_set(json_error_t *error, const lex_t *lex,
                 result = msg_text;
             }
             else {
-                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH,
+                snprintf(msg_with_context, sizeof(msg_with_context),
                          "%s near end of file", msg_text);
-                msg_with_context[JSON_ERROR_TEXT_LENGTH - 1] = '\0';
                 result = msg_with_context;
             }
         }


### PR DESCRIPTION
With gcc 8.2 there is the following warning:

```
jansson/src/load.c: In function 'error_set':
jansson/src/load.c:118:29: warning: ' near '' directive output may be truncated writing 7 bytes into a region of size between 1 and 160 [-Wformat-truncation=]
                          "%s near '%s'", msg_text, saved_text);
                             ^~~~~~~
jansson/src/load.c:117:17: note: 'snprintf' output 9 or more bytes (assuming 168) into a destination of size 160
                 snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH,
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                          "%s near '%s'", msg_text, saved_text);
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
jansson/src/load.c:135:29: warning: ' near end of file' directive output may be truncated writing 17 bytes into a region of size between 1 and 160 [-Wformat-truncation=]
                          "%s near end of file", msg_text);
                             ^~~~~~~~~~~~~~~~~
jansson/src/load.c:134:17: note: 'snprintf' output between 18 and 177 bytes into a destination of size 160
                 snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH,
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                          "%s near end of file", msg_text);
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Adjusting the size of buffer to give enough room to snprintf.