### PR TITLE
Ensure OSS fuzz travis builds work for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
   exclude:
     - compiler: clang
       env: JANSSON_BUILD_METHOD=coverage JANSSON_CMAKE_OPTIONS="-DJANSSON_COVERAGE=ON -DJANSSON_COVERALLS=ON -DCMAKE_BUILD_TYPE=Debug" JANSSON_EXTRA_INSTALL="lcov curl"
+    - compiler: clang
+      env: JANSSON_BUILD_METHOD=fuzzer
   allow_failures:
     - env: JANSSON_BUILD_METHOD=coverage JANSSON_CMAKE_OPTIONS="-DJANSSON_COVERAGE=ON -DJANSSON_COVERALLS=ON -DCMAKE_BUILD_TYPE=Debug" JANSSON_EXTRA_INSTALL="lcov curl"
 install:

--- a/test/ossfuzz/travisoss.sh
+++ b/test/ossfuzz/travisoss.sh
@@ -21,13 +21,15 @@ if [[ ${TRAVIS_PULL_REQUEST} != "false" ]]
 then
     # Pull-request branch
     REPO=${TRAVIS_PULL_REQUEST_SLUG}
+    BRANCH=${TRAVIS_PULL_REQUEST_BRANCH}
 else
     # Push build.
     REPO=${TRAVIS_REPO_SLUG}
+    BRANCH=${TRAVIS_BRANCH}
 fi
 
 # Modify the oss-fuzz Dockerfile so that we're checking out the current branch on travis.
-sed -i "s@https://github.com/akheron/jansson.git@-b ${TRAVIS_BRANCH} https://github.com/${REPO}.git@" /tmp/ossfuzz/projects/${PROJECT_NAME}/Dockerfile
+sed -i "s@https://github.com/akheron/jansson.git@-b ${BRANCH} https://github.com/${REPO}.git@" /tmp/ossfuzz/projects/${PROJECT_NAME}/Dockerfile
 
 # Try and build the fuzzers
 pushd /tmp/ossfuzz

--- a/test/ossfuzz/travisoss.sh
+++ b/test/ossfuzz/travisoss.sh
@@ -16,8 +16,18 @@ then
     exit 0
 fi
 
+# Work out which repo to clone from, inside Docker
+if [[ ${TRAVIS_PULL_REQUEST} != "false" ]]
+then
+    # Pull-request branch
+    REPO=${TRAVIS_PULL_REQUEST_SLUG}
+else
+    # Push build.
+    REPO=${TRAVIS_REPO_SLUG}
+fi
+
 # Modify the oss-fuzz Dockerfile so that we're checking out the current branch on travis.
-sed -i "s@https://github.com/akheron/jansson.git@-b $TRAVIS_BRANCH https://github.com/akheron/jansson.git@" /tmp/ossfuzz/projects/${PROJECT_NAME}/Dockerfile
+sed -i "s@https://github.com/akheron/jansson.git@-b ${TRAVIS_BRANCH} https://github.com/${REPO}.git@" /tmp/ossfuzz/projects/${PROJECT_NAME}/Dockerfile
 
 # Try and build the fuzzers
 pushd /tmp/ossfuzz


### PR DESCRIPTION
Use the correct repository for cloning when doing a push build or a pull-request.

Also, only do one fuzzer build!