### PR TITLE
ossfuzz: Zip up all "input" files to use as a seed corpus

### DIFF
--- a/test/ossfuzz/ossfuzz.sh
+++ b/test/ossfuzz/ossfuzz.sh
@@ -25,3 +25,6 @@ make
 
 # Copy the fuzzer to the output directory.
 cp -v test/ossfuzz/json_load_dump_fuzzer $OUT/
+
+# Zip up all input files to use as a test corpus
+find test/suites -name "input" -print | zip $OUT/json_load_dump_fuzzer_seed_corpus.zip -@


### PR DESCRIPTION
@Dor1s suggested that if we zip up all the "input" files from the test/suites directory, then that would be good to use as a seed corpus. I don't necessarily know if these will work as inputs (the directory structure is maintained here, and the inputs don't respect the fact that there's a certain number of header bytes used for command flags for fuzzer inputs) but in the hope that they are correct, here is a PR which zips up all the input files :smile: