### PR TITLE
Fix various typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Notes:
 #
 # Author: Paul Harris, June 2012
-# Additions: Joakim Soderberg, Febuary 2013
+# Additions: Joakim Soderberg, February 2013
 #
 # Supports: building static/shared, release/debug/etc, can also build html docs
 # and some of the tests.
@@ -35,7 +35,7 @@
 # >> make test (to run the tests, if you enabled them)
 #
 # Brief description on how it works:
-# There is a small heirachy of CMakeLists.txt files which define how the
+# There is a small hierarchy of CMakeLists.txt files which define how the
 # project is built.
 # Header file detection etc is done, and the results are written into config.h
 # and jansson_config.h, which are generated from the corresponding
@@ -100,7 +100,7 @@ include (CheckFunctionKeywords)
 include (CheckIncludeFiles)
 include (CheckTypeSize)
 
-# supress format-truncation warning
+# suppress format-truncation warning
 include (CheckCCompilerFlag)
 check_c_compiler_flag(-Wno-format-truncation HAS_NO_FORMAT_TRUNCATION)
 if (HAS_NO_FORMAT_TRUNCATION)
@@ -215,7 +215,7 @@ else ()
    set (JSON_UINT8 "unsigned char")
 endif ()
 
-# Check for ssize_t and SSIZE_T existance.
+# Check for ssize_t and SSIZE_T existence.
 check_type_size(ssize_t SSIZE_T)
 check_type_size(SSIZE_T UPPERCASE_SSIZE_T)
 if(NOT HAVE_SSIZE_T)

--- a/cmake/CoverallsGenerateGcov.cmake
+++ b/cmake/CoverallsGenerateGcov.cmake
@@ -102,8 +102,8 @@ if (GIT_FOUND)
 	message("Git branch: ${GIT_BRANCH}")
 	message("Git author: ${GIT_AUTHOR_NAME}")
 	message("Git e-mail: ${GIT_AUTHOR_EMAIL}")
-	message("Git commiter name: ${GIT_COMMITTER_NAME}")
-	message("Git commiter e-mail: ${GIT_COMMITTER_EMAIL}")
+	message("Git committer name: ${GIT_COMMITTER_NAME}")
+	message("Git committer e-mail: ${GIT_COMMITTER_EMAIL}")
 	message("Git commit message: ${GIT_COMMIT_MESSAGE}")
 
 endif()
@@ -265,7 +265,7 @@ foreach (GCOV_FILE ${GCOV_FILES})
 	# Instead of trying to parse the source from the
 	# gcov file, simply read the file contents from the source file.
 	# (Parsing it from the gcov is hard because C-code uses ; in many places
-	#  which also happens to be the same as the CMake list delimeter).
+	#  which also happens to be the same as the CMake list delimiter).
 	file(READ ${GCOV_SRC_PATH} GCOV_FILE_SOURCE)
 
 	string(REPLACE "\\" "\\\\" GCOV_FILE_SOURCE "${GCOV_FILE_SOURCE}")

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -74,7 +74,7 @@ function::
 
     static char *request(const char *url);
 
-It takes the URL as a parameter, preforms a HTTP GET request, and
+It takes the URL as a parameter, performs a HTTP GET request, and
 returns a newly allocated string that contains the response body. If
 the request fails, an error message is printed to stderr and the
 return value is *NULL*. For full details, refer to :download:`the code

--- a/src/lookup3.h
+++ b/src/lookup3.h
@@ -243,7 +243,7 @@ static uint32_t hashlittle(const void *key, size_t length, uint32_t initval)
      * rest of the string.  Every machine with memory protection I've seen
      * does it on word boundaries, so is OK with this.  But VALGRIND will
      * still catch it and complain.  The masking trick does make the hash
-     * noticably faster for short strings (like English words).
+     * noticeably faster for short strings (like English words).
      */
 #ifndef NO_MASKING_TRICK
 

--- a/test/suites/api/test_array.c
+++ b/test/suites/api/test_array.c
@@ -186,7 +186,7 @@ static void test_insert(void)
 
     for(i = 0; i < 20; i++) {
         if(json_array_insert(array, 0, seven))
-            fail("unable to insert value at the begining of an array");
+            fail("unable to insert value at the beginning of an array");
     }
 
     for(i = 0; i < 20; i++) {
@@ -479,9 +479,9 @@ static void test_bad_args(void)
     if(!json_array_extend(num, arr))
         fail("json_array_extend did not return error for first argument non-array");
     if(!json_array_extend(arr, NULL))
-        fail("json_array_extend did not return error for second arguemnt non-array");
+        fail("json_array_extend did not return error for second argument non-array");
     if(!json_array_extend(arr, num))
-        fail("json_array_extend did not return error for second arguemnt non-array");
+        fail("json_array_extend did not return error for second argument non-array");
 
     if(num->refcount != 1)
         fail("unexpected reference count on num");

--- a/test/suites/api/test_object.c
+++ b/test/suites/api/test_object.c
@@ -59,7 +59,7 @@ static void test_update()
     /* update an empty object with an empty object */
 
     if(json_object_update(object, other))
-        fail("unable to update an emtpy object with an empty object");
+        fail("unable to update an empty object with an empty object");
 
     if(json_object_size(object) != 0)
         fail("invalid size after update");


### PR DESCRIPTION
Found via `codespell -q 2` (v1.17.0.dev0)