### PR TITLE
fix issue #441: remove strtod definition in strconv.c

### DIFF
--- a/src/strconv.c
+++ b/src/strconv.c
@@ -14,10 +14,6 @@
 #include <jansson_private_config.h>
 #endif
 
-#ifdef __MINGW32__
-#define strtod __strtod
-#endif
-
 #if JSON_HAVE_LOCALECONV
 #include <locale.h>
 

--- a/src/strconv.c
+++ b/src/strconv.c
@@ -3,9 +3,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#ifdef __MINGW32__
-#undef __NO_ISOCEXT /* ensure stdlib.h will declare prototypes for mingw own 'strtod' replacement, called '__strtod' */
-#endif
 #include "jansson_private.h"
 #include "strbuffer.h"
 


### PR DESCRIPTION
It already has "strtod" function in stdlib.h and because __USE_MINGW_ANSI_STDIO is desperated