### PR TITLE
add changes since v2.12

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,23 +15,19 @@ Released xxxx-xx-xx
 
 * Build:
 
-  - Add -Wno-format-truncation to suppress format truncation warnings (#489).
+  - Add ``-Wno-format-truncation`` to suppress format truncation warnings (#489).
 
 * Bug fixes:
 
-  - Remove `strtod` macro definition for MinGW (#498).
+  - Remove ``strtod`` macro definition for MinGW (#498).
 
   - Add infinite loop check in `json_deep_copy()` (#490).
 
-  - Add `pipe` macro definition for MinGW (#500).
+  - Add ``pipe`` macro definition for MinGW (#500).
 
-  - Enhance `JANSSON_ATTRS` macro to support earlier C standard(C89) (#501).
+  - Enhance ``JANSSON_ATTRS`` macro to support earlier C standard(C89) (#501).
 
   - Update version detection for sphinx-build (#502).
-
-* Tests:
-
-  - Add negative test case for `test_equal_complex()` (#506).
 
 * Documentation:
 
@@ -45,12 +41,6 @@ Released xxxx-xx-xx
   - Document that non-blocking file descriptor is not supported on
     `json_loadfd()` (#503).
 
-  - Format code with clang-format (#508).
-
-* Other:
-
-  - Add fuzz target for jansson to integrate jansson with OSS-Fuzz (#480,
-    #484, #485, #486, #487).
 
 Version 2.12
 ============

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,59 @@
+Version 2.13
+============
+
+Released xxxx-xx-xx
+
+* New Features:
+
+  - Add `jansson_version_str()` and `jansson_version_cmp()` for runtime
+    version checking (#465).
+
+  - Add `json_object_update_new()`, `json_object_update_existing_new()`
+    and `json_object_update_missing_new()` functions (#499).
+
+  - Add `json_object_update_recursive()` (#505).
+
+* Build:
+
+  - Add -Wno-format-truncation to suppress format truncation warnings (#489).
+
+* Bug fixes:
+
+  - Remove `strtod` macro definition for MinGW (#498).
+
+  - Add infinite loop check in `json_deep_copy()` (#490).
+
+  - Add `pipe` macro definition for MinGW (#500).
+
+  - Enhance `JANSSON_ATTRS` macro to support earlier C standard(C89) (#501).
+
+  - Update version detection for sphinx-build (#502).
+
+* Tests:
+
+  - Add negative test case for `test_equal_complex()` (#506).
+
+* Documentation:
+
+  - Fix typos (#483, #494).
+
+  - Document that call the custom free function to free the return value 
+    of `json_dumps()` if you have a custom malloc/free (#490).
+
+  - Add vcpkg installation instructions (#496).
+
+  - Document that non-blocking file descriptor is not supported on
+    `json_loadfd()` (#503).
+
+  - Format code with clang-format (#508).
+
+* Other:
+
+  - Add fuzz target for jansson to integrate jansson with OSS-Fuzz (#480,
+    #484, #485, #486, #487).
+
 Version 2.12
+============
 
 Released 2018-11-26
 


### PR DESCRIPTION
I update the CHANGES file with changes since v2.12. @akheron I have no idea when you will release v2.13 so I leave the release date there with "xxxx-xx-xx". Most of these changes listed are from the PRs merged since v2.12 was released.