### PR TITLE
Enable and fix additional warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,12 @@ include (CheckTypeSize)
 include (CheckCCompilerFlag)
 check_c_compiler_flag(-Wno-format-truncation HAS_NO_FORMAT_TRUNCATION)
 if (HAS_NO_FORMAT_TRUNCATION)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-truncation")
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-truncation")
+endif()
+
+check_c_compiler_flag(-Wstrict-prototypes HAS_STRICT_PROTOTYPES)
+if (HAS_STRICT_PROTOTYPES)
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wstrict-prototypes")
 endif()
 
 if (MSVC)
@@ -496,7 +501,7 @@ if (NOT JANSSON_WITHOUT_TESTS)
    # Test suites.
    #
    if (CMAKE_COMPILER_IS_GNUCC)
-      add_definitions(-Wall -Wextra -Wdeclaration-after-statement)
+      add_definitions(-pedantic -Wall -Wextra -Wdeclaration-after-statement)
    endif ()
 
    set(api_tests

--- a/configure.ac
+++ b/configure.ac
@@ -158,7 +158,14 @@ if test x$GCC = xyes; then
       [AC_MSG_RESULT(no)
       wnoformat_truncation=""])
 
-    AM_CFLAGS="-Wall -Wextra -Wdeclaration-after-statement -Wshadow ${wnoformat_truncation}"
+    AC_MSG_CHECKING(for -Wstrict-prototypes)
+    wstrict_prototypes="-Wstrict-prototypes"
+    AS_IF([${CC} -Wstrict-prototypes -Werror -S -o /dev/null -xc /dev/null > /dev/null 2>&1],
+      [AC_MSG_RESULT(yes)],
+      [AC_MSG_RESULT(no)
+      wstrict_prototypes=""])
+
+    AM_CFLAGS="-pedantic -Wall -Wextra -Wdeclaration-after-statement -Wshadow ${wnoformat_truncation} ${wstrict_prototypes}"
 fi
 AC_SUBST([AM_CFLAGS])
 

--- a/src/hashtable_seed.c
+++ b/src/hashtable_seed.c
@@ -164,7 +164,7 @@ static int seed_from_timestamp_and_pid(uint32_t *seed) {
     return 0;
 }
 
-static uint32_t generate_seed() {
+static uint32_t generate_seed(void) {
     uint32_t seed = 0;
     int done = 0;
 

--- a/src/value.c
+++ b/src/value.c
@@ -46,7 +46,7 @@ static JSON_INLINE void json_init(json_t *json, json_type type) {
 
 int jsonp_loop_check(hashtable_t *parents, const json_t *json, char *key,
                      size_t key_size) {
-    snprintf(key, key_size, "%p", json);
+    snprintf(key, key_size, "%p", (void *)json);
     if (hashtable_get(parents, key))
         return -1;
 

--- a/test/bin/json_process.c
+++ b/test/bin/json_process.c
@@ -242,7 +242,7 @@ static int getenv_int(const char *name) {
     return (int)result;
 }
 
-int use_env() {
+int use_env(void) {
     int indent, precision;
     size_t flags = 0;
     json_t *json;

--- a/test/suites/api/test_array.c
+++ b/test/suites/api/test_array.c
@@ -337,7 +337,7 @@ static void test_extend(void) {
     json_decref(array2);
 }
 
-static void test_circular() {
+static void test_circular(void) {
     json_t *array1, *array2;
 
     /* the simple cases are checked */
@@ -380,7 +380,7 @@ static void test_circular() {
     json_decref(array1);
 }
 
-static void test_array_foreach() {
+static void test_array_foreach(void) {
     size_t index;
     json_t *array1, *array2, *value;
 
@@ -472,7 +472,7 @@ static void test_bad_args(void) {
     json_decref(arr);
 }
 
-static void run_tests() {
+static void run_tests(void) {
     test_misc();
     test_insert();
     test_remove();

--- a/test/suites/api/test_chaos.c
+++ b/test/suites/api/test_chaos.c
@@ -38,7 +38,7 @@ void chaos_free(void *obj) { free(obj); }
 #define chaos_loop_new_value(json, initcall)                                             \
     chaos_loop(!json, json = initcall;, json_decref(json); json = NULL;)
 
-int test_unpack() {
+int test_unpack(void) {
     int ret = -1;
     int v1;
     int v2;
@@ -83,7 +83,7 @@ int dump_chaos_callback(const char *buffer, size_t size, void *data) {
     return 0;
 }
 
-static void test_chaos() {
+static void test_chaos(void) {
     json_malloc_t orig_malloc;
     json_free_t orig_free;
     json_t *json = NULL;
@@ -165,4 +165,4 @@ static void test_chaos() {
     json_decref(dumpobj);
 }
 
-static void run_tests() { test_chaos(); }
+static void run_tests(void) { test_chaos(); }

--- a/test/suites/api/test_copy.c
+++ b/test/suites/api/test_copy.c
@@ -364,7 +364,7 @@ static void test_deep_copy_circular_references(void) {
     json_decref(json);
 }
 
-static void run_tests() {
+static void run_tests(void) {
     test_copy_simple();
     test_deep_copy_simple();
     test_copy_array();

--- a/test/suites/api/test_dump.c
+++ b/test/suites/api/test_dump.c
@@ -25,7 +25,7 @@ static int encode_null_callback(const char *buffer, size_t size, void *data) {
     return 0;
 }
 
-static void encode_null() {
+static void encode_null(void) {
     if (json_dumps(NULL, JSON_ENCODE_ANY) != NULL)
         fail("json_dumps didn't fail for NULL");
 
@@ -46,7 +46,7 @@ static void encode_null() {
         fail("json_dump_callback didn't fail for NULL");
 }
 
-static void encode_twice() {
+static void encode_twice(void) {
     /* Encode an empty object/array, add an item, encode again */
 
     json_t *json;
@@ -81,7 +81,7 @@ static void encode_twice() {
     json_decref(json);
 }
 
-static void circular_references() {
+static void circular_references(void) {
     /* Construct a JSON object/array with a circular reference:
 
        object: {"a": {"b": {"c": <circular reference to $.a>}}}
@@ -130,7 +130,7 @@ static void circular_references() {
     json_decref(json);
 }
 
-static void encode_other_than_array_or_object() {
+static void encode_other_than_array_or_object(void) {
     /* Encoding anything other than array or object should only
      * succeed if the JSON_ENCODE_ANY flag is used */
 
@@ -168,7 +168,7 @@ static void encode_other_than_array_or_object() {
     json_decref(json);
 }
 
-static void escape_slashes() {
+static void escape_slashes(void) {
     /* Test dump escaping slashes */
 
     json_t *json;
@@ -192,7 +192,7 @@ static void escape_slashes() {
     json_decref(json);
 }
 
-static void encode_nul_byte() {
+static void encode_nul_byte(void) {
     json_t *json;
     char *result;
 
@@ -205,7 +205,7 @@ static void encode_nul_byte() {
     json_decref(json);
 }
 
-static void dump_file() {
+static void dump_file(void) {
     json_t *json;
     int result;
 
@@ -222,7 +222,7 @@ static void dump_file() {
     remove("json_dump_file.json");
 }
 
-static void dumpb() {
+static void dumpb(void) {
     char buf[2];
     json_t *obj;
     size_t size;
@@ -243,7 +243,7 @@ static void dumpb() {
     json_decref(obj);
 }
 
-static void dumpfd() {
+static void dumpfd(void) {
 #ifdef HAVE_UNISTD_H
     int fds[2] = {-1, -1};
     json_t *a, *b;
@@ -270,7 +270,7 @@ static void dumpfd() {
 #endif
 }
 
-static void embed() {
+static void embed(void) {
     static const char *plains[] = {"{\"bar\":[],\"foo\":{}}", "[[],{}]", "{}", "[]",
                                    NULL};
 
@@ -297,7 +297,7 @@ static void embed() {
     }
 }
 
-static void run_tests() {
+static void run_tests(void) {
     encode_null();
     encode_twice();
     circular_references();

--- a/test/suites/api/test_dump_callback.c
+++ b/test/suites/api/test_dump_callback.c
@@ -26,7 +26,7 @@ static int my_writer(const char *buffer, size_t len, void *data) {
     return 0;
 }
 
-static void run_tests() {
+static void run_tests(void) {
     struct my_sink s;
     json_t *json;
     const char str[] = "[\"A\", {\"B\": \"C\", \"e\": false}, 1, null, \"foo\"]";

--- a/test/suites/api/test_equal.c
+++ b/test/suites/api/test_equal.c
@@ -8,7 +8,7 @@
 #include "util.h"
 #include <jansson.h>
 
-static void test_equal_simple() {
+static void test_equal_simple(void) {
     json_t *value1, *value2;
 
     if (json_equal(NULL, NULL))
@@ -85,7 +85,7 @@ static void test_equal_simple() {
     json_decref(value2);
 }
 
-static void test_equal_array() {
+static void test_equal_array(void) {
     json_t *array1, *array2;
 
     array1 = json_array();
@@ -117,7 +117,7 @@ static void test_equal_array() {
     json_decref(array2);
 }
 
-static void test_equal_object() {
+static void test_equal_object(void) {
     json_t *object1, *object2;
 
     object1 = json_object();
@@ -154,7 +154,7 @@ static void test_equal_object() {
     json_decref(object2);
 }
 
-static void test_equal_complex() {
+static void test_equal_complex(void) {
     json_t *value1, *value2, *value3;
 
     const char *complex_json = "{"
@@ -194,7 +194,7 @@ static void test_equal_complex() {
     json_decref(value3);
 }
 
-static void run_tests() {
+static void run_tests(void) {
     test_equal_simple();
     test_equal_array();
     test_equal_object();

--- a/test/suites/api/test_load.c
+++ b/test/suites/api/test_load.c
@@ -9,7 +9,7 @@
 #include <jansson.h>
 #include <string.h>
 
-static void file_not_found() {
+static void file_not_found(void) {
     json_t *json;
     json_error_t error;
     char *pos;
@@ -35,7 +35,7 @@ static void file_not_found() {
         fail("json_load_file returned an invalid error code");
 }
 
-static void very_long_file_name() {
+static void very_long_file_name(void) {
     json_t *json;
     json_error_t error;
 
@@ -53,7 +53,7 @@ static void very_long_file_name() {
         fail("error code was set incorrectly");
 }
 
-static void reject_duplicates() {
+static void reject_duplicates(void) {
     json_error_t error;
 
     if (json_loads("{\"foo\": 1, \"foo\": 2}", JSON_REJECT_DUPLICATES, &error))
@@ -62,7 +62,7 @@ static void reject_duplicates() {
                 "<string>", 1, 16, 16);
 }
 
-static void disable_eof_check() {
+static void disable_eof_check(void) {
     json_error_t error;
     json_t *json;
 
@@ -80,7 +80,7 @@ static void disable_eof_check() {
     json_decref(json);
 }
 
-static void decode_any() {
+static void decode_any(void) {
     json_t *json;
     json_error_t error;
 
@@ -105,7 +105,7 @@ static void decode_any() {
     json_decref(json);
 }
 
-static void decode_int_as_real() {
+static void decode_int_as_real(void) {
     json_t *json;
     json_error_t error;
 
@@ -145,7 +145,7 @@ static void decode_int_as_real() {
     json_decref(json);
 }
 
-static void allow_nul() {
+static void allow_nul(void) {
     const char *text = "\"nul byte \\u0000 in string\"";
     const char *expected = "nul byte \0 in string";
     size_t len = 20;
@@ -164,7 +164,7 @@ static void allow_nul() {
     json_decref(json);
 }
 
-static void load_wrong_args() {
+static void load_wrong_args(void) {
     json_t *json;
     json_error_t error;
 
@@ -189,7 +189,7 @@ static void load_wrong_args() {
         fail("json_load_file should return NULL if the first argument is NULL");
 }
 
-static void position() {
+static void position(void) {
     json_t *json;
     size_t flags = JSON_DISABLE_EOF_CHECK;
     json_error_t error;
@@ -205,7 +205,7 @@ static void position() {
     json_decref(json);
 }
 
-static void error_code() {
+static void error_code(void) {
     json_error_t error;
     json_t *json = json_loads("[123] garbage", 0, &error);
     if (json != NULL)
@@ -224,7 +224,7 @@ static void error_code() {
         fail("json_loads returned incorrect error code");
 }
 
-static void run_tests() {
+static void run_tests(void) {
     file_not_found();
     very_long_file_name();
     reject_duplicates();

--- a/test/suites/api/test_load_callback.c
+++ b/test/suites/api/test_load_callback.c
@@ -31,7 +31,7 @@ static size_t greedy_reader(void *buf, size_t buflen, void *arg) {
     }
 }
 
-static void run_tests() {
+static void run_tests(void) {
     struct my_source s;
     json_t *json;
     json_error_t error;

--- a/test/suites/api/test_loadb.c
+++ b/test/suites/api/test_loadb.c
@@ -9,7 +9,7 @@
 #include <jansson.h>
 #include <string.h>
 
-static void run_tests() {
+static void run_tests(void) {
     json_t *json;
     json_error_t error;
     const char str[] = "[\"A\", {\"B\": \"C\"}, 1, 2, 3]garbage";

--- a/test/suites/api/test_memory_funcs.c
+++ b/test/suites/api/test_memory_funcs.c
@@ -8,7 +8,7 @@ static int free_called = 0;
 static size_t malloc_used = 0;
 
 /* helpers */
-static void create_and_free_complex_object() {
+static void create_and_free_complex_object(void) {
     json_t *obj;
 
     obj = json_pack("{s:i,s:n,s:b,s:b,s:{s:s},s:[i,i,i]}", "foo", 42, "bar", "baz", 1,
@@ -17,7 +17,7 @@ static void create_and_free_complex_object() {
     json_decref(obj);
 }
 
-static void create_and_free_object_with_oom() {
+static void create_and_free_object_with_oom(void) {
     int i;
     char key[4];
     json_t *obj = json_object();
@@ -40,7 +40,7 @@ static void my_free(void *ptr) {
     free(ptr);
 }
 
-static void test_simple() {
+static void test_simple(void) {
     json_malloc_t mfunc = NULL;
     json_free_t ffunc = NULL;
 
@@ -65,7 +65,7 @@ static void oom_free(void *ptr) {
     free(ptr);
 }
 
-static void test_oom() {
+static void test_oom(void) {
     free_called = 0;
     json_set_alloc_funcs(oom_malloc, oom_free);
     create_and_free_object_with_oom();
@@ -107,7 +107,7 @@ static void test_bad_args(void) {
     json_get_alloc_funcs(NULL, NULL);
 }
 
-static void run_tests() {
+static void run_tests(void) {
     test_simple();
     test_secure_funcs();
     test_oom();

--- a/test/suites/api/test_number.c
+++ b/test/suites/api/test_number.c
@@ -17,7 +17,7 @@
 #pragma warning(push)
 #pragma warning(disable : 4756)
 #endif
-static void test_inifity() {
+static void test_inifity(void) {
     json_t *real = json_real(INFINITY);
     if (real != NULL)
         fail("could construct a real from Inf");
@@ -70,7 +70,7 @@ static void test_bad_args(void) {
     json_decref(txt);
 }
 
-static void run_tests() {
+static void run_tests(void) {
     json_t *integer, *real;
     json_int_t i;
     double d;

--- a/test/suites/api/test_object.c
+++ b/test/suites/api/test_object.c
@@ -9,7 +9,7 @@
 #include <jansson.h>
 #include <string.h>
 
-static void test_clear() {
+static void test_clear(void) {
     json_t *object, *ten;
 
     object = json_object();
@@ -37,7 +37,7 @@ static void test_clear() {
     json_decref(object);
 }
 
-static void test_update() {
+static void test_update(void) {
     json_t *object, *other, *nine, *ten;
 
     object = json_object();
@@ -143,7 +143,7 @@ static void test_update() {
     json_decref(object);
 }
 
-static void test_set_many_keys() {
+static void test_set_many_keys(void) {
     json_t *object, *value;
     const char *keys = "abcdefghijklmnopqrstuvwxyz";
     char buf[2];
@@ -168,7 +168,7 @@ static void test_set_many_keys() {
     json_decref(value);
 }
 
-static void test_conditional_updates() {
+static void test_conditional_updates(void) {
     json_t *object, *other;
 
     object = json_pack("{sisi}", "foo", 1, "bar", 2);
@@ -246,7 +246,7 @@ static void test_conditional_updates() {
     json_decref(other);
 }
 
-static void test_recursive_updates() {
+static void test_recursive_updates(void) {
     json_t *invalid, *object, *other, *barBefore, *barAfter;
 
     invalid = json_integer(42);
@@ -325,7 +325,7 @@ static void test_recursive_updates() {
     json_decref(other);
 }
 
-static void test_circular() {
+static void test_circular(void) {
     json_t *object1, *object2;
 
     object1 = json_object();
@@ -351,7 +351,7 @@ static void test_circular() {
     json_decref(object1);
 }
 
-static void test_set_nocheck() {
+static void test_set_nocheck(void) {
     json_t *object, *string;
 
     object = json_object();
@@ -388,7 +388,7 @@ static void test_set_nocheck() {
     json_decref(object);
 }
 
-static void test_iterators() {
+static void test_iterators(void) {
     json_t *object, *foo, *bar, *baz;
     void *iter;
 
@@ -467,7 +467,7 @@ static void test_iterators() {
     json_decref(baz);
 }
 
-static void test_misc() {
+static void test_misc(void) {
     json_t *object, *string, *other_string, *value;
 
     object = json_object();
@@ -577,7 +577,7 @@ static void test_misc() {
     json_decref(object);
 }
 
-static void test_preserve_order() {
+static void test_preserve_order(void) {
     json_t *object;
     char *result;
 
@@ -612,7 +612,7 @@ static void test_preserve_order() {
     json_decref(object);
 }
 
-static void test_object_foreach() {
+static void test_object_foreach(void) {
     const char *key;
     json_t *object1, *object2, *value;
 
@@ -628,7 +628,7 @@ static void test_object_foreach() {
     json_decref(object2);
 }
 
-static void test_object_foreach_safe() {
+static void test_object_foreach_safe(void) {
     const char *key;
     void *tmp;
     json_t *object, *value;
@@ -780,7 +780,7 @@ static void test_bad_args(void) {
     json_decref(num);
 }
 
-static void run_tests() {
+static void run_tests(void) {
     test_misc();
     test_clear();
     test_update();

--- a/test/suites/api/test_pack.c
+++ b/test/suites/api/test_pack.c
@@ -26,7 +26,7 @@
 #pragma warning(push)
 #pragma warning(disable : 4756)
 #endif
-static void test_inifity() {
+static void test_inifity(void) {
     json_error_t error;
 
     if (json_pack_ex(&error, 0, "f", INFINITY))
@@ -50,7 +50,7 @@ static void test_inifity() {
 }
 #endif // INFINITY
 
-static void run_tests() {
+static void run_tests(void) {
     json_t *value;
     int i;
     char buffer[4] = {'t', 'e', 's', 't'};

--- a/test/suites/api/test_simple.c
+++ b/test/suites/api/test_simple.c
@@ -59,7 +59,7 @@ static void test_bad_args(void) {
 }
 
 /* Call the simple functions not covered by other tests of the public API */
-static void run_tests() {
+static void run_tests(void) {
     json_t *value;
 
     value = json_boolean(1);

--- a/test/suites/api/test_sprintf.c
+++ b/test/suites/api/test_sprintf.c
@@ -2,7 +2,7 @@
 #include <jansson.h>
 #include <string.h>
 
-static void test_sprintf() {
+static void test_sprintf(void) {
     json_t *s = json_sprintf("foo bar %d", 42);
     if (!s)
         fail("json_sprintf returned NULL");
@@ -26,4 +26,4 @@ static void test_sprintf() {
         fail("json_sprintf unexpected success with invalid UTF");
 }
 
-static void run_tests() { test_sprintf(); }
+static void run_tests(void) { test_sprintf(); }

--- a/test/suites/api/test_unpack.c
+++ b/test/suites/api/test_unpack.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 
-static void run_tests() {
+static void run_tests(void) {
     json_t *j, *j2;
     int i1, i2, i3;
     json_int_t I1;

--- a/test/suites/api/test_version.c
+++ b/test/suites/api/test_version.c
@@ -15,7 +15,7 @@ static void test_version_str(void) {
     }
 }
 
-static void test_version_cmp() {
+static void test_version_cmp(void) {
     if (jansson_version_cmp(JANSSON_MAJOR_VERSION, JANSSON_MINOR_VERSION,
                             JANSSON_MICRO_VERSION)) {
         fail("jansson_version_cmp equality check failed");
@@ -55,7 +55,7 @@ static void test_version_cmp() {
     }
 }
 
-static void run_tests() {
+static void run_tests(void) {
     test_version_str();
     test_version_cmp();
 }

--- a/test/suites/api/util.h
+++ b/test/suites/api/util.h
@@ -80,9 +80,9 @@
 #define check_error(code_, text_, source_, line_, column_, position_)                    \
     check_errors(code_, &text_, 1, source_, line_, column_, position_)
 
-static void run_tests();
+static void run_tests(void);
 
-int main() {
+int main(void) {
 #ifdef HAVE_SETLOCALE
     setlocale(LC_ALL, "");
 #endif


### PR DESCRIPTION
Enable pedantic, strict prototypes, and treat warnings as errors

Resolve several cases of: function declaration isn’t a prototype
[-Werror=strict-prototypes]

Resolve: format ‘%p’ expects argument of type ‘void *’, but argument 4
has type ‘const json_t * {aka const struct json_t *}’ [-Werror=format=]