### PR TITLE
fix: decref deletes json_t val even if refcount == 0

### DIFF
--- a/src/jansson.h
+++ b/src/jansson.h
@@ -129,7 +129,7 @@ static JSON_INLINE json_t *json_incref(json_t *json) {
 void json_delete(json_t *json);
 
 static JSON_INLINE void json_decref(json_t *json) {
-    if (json && json->refcount != (size_t)-1 && JSON_INTERNAL_DECREF(json) == 0)
+    if (json && json->refcount > 0 && JSON_INTERNAL_DECREF(json) == 0)
         json_delete(json);
 }
 


### PR DESCRIPTION
json_decref will attempt to decrease refcount even if refcount == 0 and subsequently try to delete an already deleted json_t value. This can cause a double free.

This fix simply returns from the json_decref function without doing anything, if refcount == 0, i.e. already decref-ed and deleted.