### PR TITLE
add jansson_* to shared library exports

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,6 +24,6 @@ libjansson_la_SOURCES = \
 	version.c
 libjansson_la_LDFLAGS = \
 	-no-undefined \
-	-export-symbols-regex '^json_' \
+	-export-symbols-regex '^json_|^jansson_' \
 	-version-info 16:0:12 \
 	@JSON_BSYMBOLIC_LDFLAGS@

--- a/test/suites/api/check-exports
+++ b/test/suites/api/check-exports
@@ -7,7 +7,7 @@ SOFILE="../src/.libs/libjansson.so"
 
 # The list of symbols, which the shared object should export, is read
 # from the def file, which is used in Windows builds
-grep 'json_' $top_srcdir/src/jansson.def \
+grep 'json_\|jansson_' $top_srcdir/src/jansson.def \
     | sed -e 's/ //g' \
     | sort \
     >$test_log/exports


### PR DESCRIPTION
In 76300601d `jansson_version_str` and `jansson_version_cmp` were added.  But they are not in the shared library interface.  So with `--disable-static` in `configure` line, `make check` fails with `undefined reference to 'jansson_version_cmp'`.

This PR fixes it.