### PR TITLE
add `scripts` directory to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DIST = CHANGES LICENSE README.rst CMakeLists.txt cmake android examples
+EXTRA_DIST = CHANGES LICENSE README.rst CMakeLists.txt cmake android examples scripts
 SUBDIRS = doc src test
 
 # "make distcheck" builds the dvi target, so use it to check that the


### PR DESCRIPTION
Now jansson-2.13 tarball does not contain `scripts` directory, causing clang-format-check to fail.  This PR fixes that.