### PR TITLE
add json_object_getn for substring

### DIFF
--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -92,6 +92,17 @@ int hashtable_set(hashtable_t *hashtable, const char *key, json_t *value);
 void *hashtable_get(hashtable_t *hashtable, const char *key);
 
 /**
+ * hashtable_get - Get a value associated with a key
+ *
+ * @hashtable: The hashtable object
+ * @key: The key
+ * @len: The lenght key
+ *
+ * Returns value if it is found, or NULL otherwise.
+ */
+void *hashtable_getn(hashtable_t *hashtable, const char *key, size_t len);
+
+/**
  * hashtable_del - Remove a value from the hashtable
  *
  * @hashtable: The hashtable object

--- a/src/jansson.h
+++ b/src/jansson.h
@@ -188,6 +188,8 @@ void json_object_seed(size_t seed);
 size_t json_object_size(const json_t *object);
 json_t *json_object_get(const json_t *object, const char *key)
     JANSSON_ATTRS((warn_unused_result));
+json_t *json_object_getn(const json_t *object, const char *key, size_t len)
+    JANSSON_ATTRS((warn_unused_result));
 int json_object_set_new(json_t *object, const char *key, json_t *value);
 int json_object_set_new_nocheck(json_t *object, const char *key, json_t *value);
 int json_object_del(json_t *object, const char *key);

--- a/src/value.c
+++ b/src/value.c
@@ -102,6 +102,16 @@ json_t *json_object_get(const json_t *json, const char *key) {
     return hashtable_get(&object->hashtable, key);
 }
 
+json_t *json_object_getn(const json_t *json, const char *key, size_t len) {
+    json_object_t *object;
+
+    if (!key || !json_is_object(json))
+        return NULL;
+
+    object = json_to_object(json);
+    return hashtable_getn(&object->hashtable, key, len);
+}
+
 int json_object_set_new_nocheck(json_t *json, const char *key, json_t *value) {
     json_object_t *object;
 


### PR DESCRIPTION
Hi, I am writing a parser for text and I often need to replace tags whose table is in jansson. And it would be convenient for me to use a string segment.
like json_string_setn

example: "Hello, $[name]", i find $[ and ] and send to json_object_getn ptr for 'name]' and len equal 4

Thanks!