### PR TITLE
Fix size_t related compiler warnings

### DIFF
--- a/examples/simple_parse.c
+++ b/examples/simple_parse.c
@@ -30,7 +30,7 @@
 void print_json(json_t *root);
 void print_json_aux(json_t *element, int indent);
 void print_json_indent(int indent);
-const char *json_plural(int count);
+const char *json_plural(size_t count);
 void print_json_object(json_t *element, int indent);
 void print_json_array(json_t *element, int indent);
 void print_json_string(json_t *element, int indent);
@@ -80,7 +80,7 @@ void print_json_indent(int indent) {
     }
 }
 
-const char *json_plural(int count) { return count == 1 ? "" : "s"; }
+const char *json_plural(size_t count) { return count == 1 ? "" : "s"; }
 
 void print_json_object(json_t *element, int indent) {
     size_t size;
@@ -90,7 +90,11 @@ void print_json_object(json_t *element, int indent) {
     print_json_indent(indent);
     size = json_object_size(element);
 
-    printf("JSON Object of %ld pair%s:\n", size, json_plural(size));
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+    printf("JSON Object of %zd pair%s:\n", size, json_plural(size));
+#else
+    printf("JSON Object of %lld pair%s:\n", (long long)size, json_plural(size));
+#endif
     json_object_foreach(element, key, value) {
         print_json_indent(indent + 2);
         printf("JSON Key: \"%s\"\n", key);
@@ -103,7 +107,11 @@ void print_json_array(json_t *element, int indent) {
     size_t size = json_array_size(element);
     print_json_indent(indent);
 
-    printf("JSON Array of %ld element%s:\n", size, json_plural(size));
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+    printf("JSON Array of %zd element%s:\n", size, json_plural(size));
+#else
+    printf("JSON Array of %lld element%s:\n", (long long)size, json_plural(size));
+#endif
     for (i = 0; i < size; i++) {
         print_json_aux(json_array_get(element, i), indent + 2);
     }

--- a/src/lookup3.h
+++ b/src/lookup3.h
@@ -73,7 +73,7 @@ on 1 byte), but shoehorning those bytes into integers efficiently is messy.
 # define HASH_BIG_ENDIAN 0
 #endif
 
-#define hashsize(n) ((uint32_t)1<<(n))
+#define hashsize(n) ((size_t)1<<(n))
 #define hashmask(n) (hashsize(n)-1)
 #define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
 

--- a/test/bin/json_process.c
+++ b/test/bin/json_process.c
@@ -63,7 +63,7 @@ static const char *strip(char *str) {
 }
 
 static char *loadfile(FILE *file) {
-    long fsize, ret;
+    size_t fsize, ret;
     char *buf;
 
     fseek(file, 0, SEEK_END);


### PR DESCRIPTION
For Windows 64-bit build using MSVC, the fact that sizeof(long) != sizeof(size_t) would generate a fair bit compiler warnings.
Using size_t consistently is a better approach than using long and size_t interchangeably.
For printing size_t variables using printf(), It is also better to take advantage of C11 "%zd" if possible.