### PR TITLE
Conditionally use stdin according to HAVE_UNISTD_H macro

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -970,9 +970,11 @@ json_t *json_loadf(FILE *input, size_t flags, json_error_t *error) {
     const char *source;
     json_t *result;
 
-    if (input == stdin)
+#ifdef HAVE_UNISTD_H
+    if (input == STDIN_FILENO)
         source = "<stdin>";
     else
+#endif
         source = "<stream>";
 
     jsonp_error_init(error, source);


### PR DESCRIPTION
This fixes the build error on the platform which doesn't supprot stdin.