### PR TITLE
Fix strncpy compile warning

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -22,11 +22,12 @@ void jsonp_error_set_source(json_error_t *error, const char *source) {
 
     length = strlen(source);
     if (length < JSON_ERROR_SOURCE_LENGTH)
-        strncpy(error->source, source, length + 1);
+        strncpy(error->source, source, JSON_ERROR_SOURCE_LENGTH);
     else {
         size_t extra = length - JSON_ERROR_SOURCE_LENGTH + 4;
         memcpy(error->source, "...", 3);
-        strncpy(error->source + 3, source + extra, length - extra + 1);
+        strncpy(error->source + 3, source + extra, JSON_ERROR_SOURCE_LENGTH - 3);
+        error->source[JSON_ERROR_SOURCE_LENGTH - 1] = '\0';
     }
 }
 


### PR DESCRIPTION
Original code caused compile warnings:

/home/mstrbldr/x86/sas/Vendor/jansson/src/error.c: In function ‘jsonp_error_set_source.part.0’:
/home/mstrbldr/x86/sas/Vendor/jansson/src/error.c:28:9: error: ‘__builtin_strncpy’ specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
   28 |         strncpy(error->source, source, length + 1);
      |         ^~~~~~~
/home/mstrbldr/x86/sas/Vendor/jansson/src/error.c:26:14: note: length computed here
   26 |     length = strlen(source);
      |              ^~~~~~~~~~~~~~
