### PR TITLE
Handle keys longer than 2 GB

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -197,7 +197,7 @@ static int dump_string(const char *str, size_t len, json_dump_callback_t dump, v
 
 struct key_len {
     const char *key;
-    int len;
+    size_t len;
 };
 
 static int compare_keys(const void *key1, const void *key2) {
@@ -209,7 +209,9 @@ static int compare_keys(const void *key1, const void *key2) {
     if (res)
         return res;
 
-    return k1->len - k2->len;
+    if (k1->len == k2->len)
+        return 0;
+    return k1->len < k2->len ? -1 : 1;
 }
 
 static int do_dump(const json_t *json, size_t flags, int depth, hashtable_t *parents,


### PR DESCRIPTION
It is possible to trigger an out of boundary read in compare_keys while
dumping json with JSON_SORT_KEYS due to a signed integer usage.

If a key is longer than 2 GB then len in key_len turns negative. The
code uses the smaller value for memory comparison. Since a negative int
becomes a huge size_t value, the memcmp call eventually triggers an out
of boundary read.

Proof of Concept:

1. Create a json file with two keys, one being larger than 2 GB:

echo -n '{"' > header.json
dd if=/dev/zero bs=1024 count=2097153 | tr '\0' 'a' > poc.json
dd if=header.json of=poc.json conv=notrunc
echo -n '":"a","a":""}' >> poc.json

2. Compile and run this proof of concept code:

```
 #include <jansson.h>
 #include <unistd.h>
int main(void) {
json_error_t error;
 json_t *json;
 if ((json = json_load_file("poc.json", 0, &error)) == NULL)
  return 1;
 if (json_dump_file(json, "/dev/null", JSON_SORT_KEYS))
  return 1;
 return 0;
}
```

Without this patch, an out of boundary read occurs.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>