### PR TITLE
modified jansson.pc generating releated Cmake var from path to string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,9 +573,9 @@ endif ()
 #
 
 # Allow the user to override installation directories.
-set(JANSSON_INSTALL_LIB_DIR       lib CACHE PATH "Installation directory for libraries")
-set(JANSSON_INSTALL_BIN_DIR       bin CACHE PATH "Installation directory for executables")
-set(JANSSON_INSTALL_INCLUDE_DIR   include CACHE PATH "Installation directory for header files")
+set(JANSSON_INSTALL_LIB_DIR       lib CACHE STRING "Installation directory for libraries")
+set(JANSSON_INSTALL_BIN_DIR       bin CACHE STRING "Installation directory for executables")
+set(JANSSON_INSTALL_INCLUDE_DIR   include CACHE STRING "Installation directory for header files")
 
 if(WIN32 AND NOT CYGWIN)
   set(DEF_INSTALL_CMAKE_DIR cmake)


### PR DESCRIPTION
modified type of JANSSON_INSTALL_LIB_DIR/JANSSON_INSTALL_BIN_DIR/JANSSON_INSTALL_INCLUDE_DIR to string

if they were path, there will be a awkward situation:
I expect to set the setting of .pc to (for Fedora rpm package) :

```
prefix=/usr
exec_prefix=${prefix}
libdir=${exec_prefix}/lib64
includedir=${prefix}/include

Name: Jansson
Description: Library for encoding, decoding and manipulating JSON data
Version: 2.13.1
Libs: -L${libdir} -ljansson
Cflags: -I${includedir}
```

but we cannot set JANSSON_INSTALL_LIB_DIR to "lib64" because its type is path, so I will get like "${exec_prefix}//builddir/build/SOURCES/jansson-2.13.1/build/lib64"
