### PR TITLE
CMake: fix typo in default-symver check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,7 +317,7 @@ if(JANSSON_BUILD_SHARED_LIBS)
       return 0;
    }
    "
-   DSYMVER_WORKS
+   SYMVER_WORKS
    )
    list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "-Wl,--default-symver")
 


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>