### PR TITLE
Remove unused ${SOURCE_DIR}/include include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,9 +602,7 @@ foreach(p LIB BIN INCLUDE CMAKE)
 endforeach()
 
 # Generate the config file for the build-tree.
-set(JANSSON__INCLUDE_DIRS
-    "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${CMAKE_CURRENT_BINARY_DIR}/include")
+set(JANSSON__INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/include")
 set(JANSSON_INCLUDE_DIRS ${JANSSON__INCLUDE_DIRS} CACHE PATH "Jansson include directories")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/janssonConfig.cmake.in
                ${CMAKE_CURRENT_BINARY_DIR}/janssonConfig.cmake


### PR DESCRIPTION
The directory `${CMAKE_CURRENT_SOURCE_DIR}/include` is never created or used. Except in case of an in-source build but then  `${CMAKE_CURRENT_BINARY_DIR}/include` would be the same, so it would only duplicate the correct entry.

Not sure if the intermediary `JANSSON__INCLUDE_DIRS` is still necessary but I thought I'd change as little as possible.

The reason for eliminating this is that when you use CLion and sync into a docker container it will try to copy all include dirs back. Non-existent paths cause warnings every time.