### PR TITLE
Port check for --default-symver to autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,9 @@ AC_TYPE_UINT16_T
 AC_TYPE_UINT8_T
 AC_TYPE_LONG_LONG_INT
 
+jansson_soversion="4"
+AC_SUBST([jansson_soversion])
+
 AC_C_INLINE
 case $ac_cv_c_inline in
     yes) json_inline=inline;;
@@ -138,8 +141,12 @@ AS_IF([test "x$with_Bsymbolic" = "xyes"], [JSON_BSYMBOLIC_LDFLAGS=-Wl[,]-Bsymbol
 AC_SUBST(JSON_BSYMBOLIC_LDFLAGS)
 
 # Enable symbol versioning on GNU libc
+m4_pattern_forbid([^AX_CHECK_LINK_FLAG$])
 JSON_SYMVER_LDFLAGS=
-AC_CHECK_DECL([__GLIBC__], [JSON_SYMVER_LDFLAGS=-Wl,--default-symver])
+AC_CHECK_DECL([__GLIBC__],
+  [AX_CHECK_LINK_FLAG([-Wl,--default-symver],
+    [JSON_SYMVER_LDFLAGS=-Wl,--default-symver],
+    [JSON_SYMVER_LDFLAGS=-Wl,--version-script,$ac_abs_confdir/jansson.sym])])
 AC_SUBST([JSON_SYMVER_LDFLAGS])
 
 AC_ARG_ENABLE([ossfuzzers],
@@ -168,6 +175,7 @@ AC_SUBST([AM_CFLAGS])
 
 AC_CONFIG_FILES([
         jansson.pc
+	jansson.sym
         Makefile
         doc/Makefile
         src/Makefile

--- a/jansson.sym.in
+++ b/jansson.sym.in
@@ -1,0 +1,5 @@
+JANSSON_@jansson_soversion@ {
+	global:
+	*;
+};
+


### PR DESCRIPTION
This commit ports the configure check for -Wl,--default-symver that is present in CMake to autoconf. This fixes building Jansson via autoconf with non-bfd linkers on glibc systems.