### PR TITLE
Adjust foreach macros to not trigger VS warning C4706

### DIFF
--- a/src/jansson.h
+++ b/src/jansson.h
@@ -213,14 +213,14 @@ int json_object_iter_set_new(json_t *object, void *iter, json_t *value);
 
 #define json_object_foreach(object, key, value)                                          \
     for (key = json_object_iter_key(json_object_iter(object));                           \
-         key && (value = json_object_iter_value(json_object_key_to_iter(key)));          \
+         key && ((value = json_object_iter_value(json_object_key_to_iter(key))) != 0);   \
          key = json_object_iter_key(                                                     \
              json_object_iter_next(object, json_object_key_to_iter(key))))
 
 #define json_object_keylen_foreach(object, key, key_len, value)                          \
     for (key = json_object_iter_key(json_object_iter(object)),                           \
         key_len = json_object_iter_key_len(json_object_key_to_iter(key));                \
-         key && (value = json_object_iter_value(json_object_key_to_iter(key)));          \
+         key && ((value = json_object_iter_value(json_object_key_to_iter(key))) != 0);   \
          key = json_object_iter_key(                                                     \
              json_object_iter_next(object, json_object_key_to_iter(key))),               \
         key_len = json_object_iter_key_len(json_object_key_to_iter(key)))
@@ -228,7 +228,7 @@ int json_object_iter_set_new(json_t *object, void *iter, json_t *value);
 #define json_object_foreach_safe(object, n, key, value)                                  \
     for (key = json_object_iter_key(json_object_iter(object)),                           \
         n = json_object_iter_next(object, json_object_key_to_iter(key));                 \
-         key && (value = json_object_iter_value(json_object_key_to_iter(key)));          \
+         key && ((value = json_object_iter_value(json_object_key_to_iter(key))) != 0);   \
          key = json_object_iter_key(n),                                                  \
         n = json_object_iter_next(object, json_object_key_to_iter(key)))
 
@@ -236,13 +236,13 @@ int json_object_iter_set_new(json_t *object, void *iter, json_t *value);
     for (key = json_object_iter_key(json_object_iter(object)),                           \
         n = json_object_iter_next(object, json_object_key_to_iter(key)),                 \
         key_len = json_object_iter_key_len(json_object_key_to_iter(key));                \
-         key && (value = json_object_iter_value(json_object_key_to_iter(key)));          \
+         key && ((value = json_object_iter_value(json_object_key_to_iter(key))) != 0);   \
          key = json_object_iter_key(n), key_len = json_object_iter_key_len(n),           \
         n = json_object_iter_next(object, json_object_key_to_iter(key)))
 
 #define json_array_foreach(array, index, value)                                          \
     for (index = 0;                                                                      \
-         index < json_array_size(array) && (value = json_array_get(array, index));       \
+         index < json_array_size(array) && ((value = json_array_get(array, index)) != 0);\
          index++)
 
 static JSON_INLINE int json_object_set(json_t *object, const char *key, json_t *value) {


### PR DESCRIPTION
It seems like the json_*_foreach() macros intentionally use an assignment in a conditional check (of a for loop). Explicitly request the assignment and then non-zero check by wrapping the assignment in parenthesis and then test the result using `!= 0`. To my understanding, this should do the same check, but in a way that hints to MSVC that you in fact really did mean to assign and then test for nonzeroness inside the for loop conditional.

As I do not understand the operation of these macros, I would request a thorough check that I did not affect their functionality.