### PR TITLE
Add option to have more control over the precision with which reals are placed in JSON with dump calls

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -246,10 +246,13 @@ static int do_dump(const json_t *json, size_t flags, int depth, hashtable_t *par
         case JSON_REAL: {
             char buffer[MAX_REAL_STR_LENGTH];
             int size;
+            int precision = json_real_precision(json);
             double value = json_real_value(json);
 
-            size = jsonp_dtostr(buffer, MAX_REAL_STR_LENGTH, value,
-                                FLAGS_TO_PRECISION(flags));
+            if (precision == DEFAULT_PRECISION_SYSTEM) 
+               precision = FLAGS_TO_PRECISION(flags);
+
+            size = jsonp_dtostr(buffer, MAX_REAL_STR_LENGTH, value, precision);
             if (size < 0)
                 return -1;
 

--- a/src/jansson.h
+++ b/src/jansson.h
@@ -99,6 +99,7 @@ json_t *json_stringn(const char *value, size_t len);
 json_t *json_string_nocheck(const char *value);
 json_t *json_stringn_nocheck(const char *value, size_t len);
 json_t *json_integer(json_int_t value);
+json_t *json_real_with_precision(double value, int precision);
 json_t *json_real(double value);
 json_t *json_true(void);
 json_t *json_false(void);
@@ -308,10 +309,13 @@ static JSON_INLINE int json_array_insert(json_t *array, size_t ind, json_t *valu
     return json_array_insert_new(array, ind, json_incref(value));
 }
 
+#define DEFAULT_PRECISION_SYSTEM   -1
+
 const char *json_string_value(const json_t *string);
 size_t json_string_length(const json_t *string);
 json_int_t json_integer_value(const json_t *integer);
 double json_real_value(const json_t *real);
+int json_real_precision(const json_t *real);
 double json_number_value(const json_t *json);
 
 int json_string_set(json_t *string, const char *value);
@@ -319,7 +323,9 @@ int json_string_setn(json_t *string, const char *value, size_t len);
 int json_string_set_nocheck(json_t *string, const char *value);
 int json_string_setn_nocheck(json_t *string, const char *value, size_t len);
 int json_integer_set(json_t *integer, json_int_t value);
+int json_real_set_with_precision(json_t *real, double value, int precision);
 int json_real_set(json_t *real, double value);
+int json_real_set_precision(json_t *json, int precision);
 
 /* pack, unpack */
 

--- a/src/jansson_private.h
+++ b/src/jansson_private.h
@@ -53,6 +53,7 @@ typedef struct {
 typedef struct {
     json_t json;
     double value;
+    int precision;
 } json_real_t;
 
 typedef struct {
@@ -79,7 +80,7 @@ void jsonp_error_vset(json_error_t *error, int line, int column, size_t position
 
 /* Locale independent string<->double conversions */
 int jsonp_strtod(strbuffer_t *strbuffer, double *out);
-int jsonp_dtostr(char *buffer, size_t size, double value, int prec);
+int jsonp_dtostr(char *buffer, size_t size, double value, int precision);
 
 /* Wrappers for custom memory functions */
 void *jsonp_malloc(size_t size) JANSSON_ATTRS((warn_unused_result));

--- a/src/value.c
+++ b/src/value.c
@@ -927,8 +927,7 @@ static json_t *json_integer_copy(const json_t *integer) {
 }
 
 /*** real ***/
-
-json_t *json_real(double value) {
+json_t *json_real_with_precision(double value, int precision) {
     json_real_t *real;
 
     if (isnan(value) || isinf(value))
@@ -940,7 +939,12 @@ json_t *json_real(double value) {
     json_init(&real->json, JSON_REAL);
 
     real->value = value;
+    real->precision = precision;
     return &real->json;
+}
+
+json_t *json_real(double value) {
+    return json_real_with_precision(value, DEFAULT_PRECISION_SYSTEM); 
 }
 
 double json_real_value(const json_t *json) {
@@ -950,13 +954,33 @@ double json_real_value(const json_t *json) {
     return json_to_real(json)->value;
 }
 
-int json_real_set(json_t *json, double value) {
+int json_real_precision(const json_t *json) {
+    if (!json_is_real(json))
+        return -1;
+
+    return json_to_real(json)->precision;
+}
+
+int json_real_set_with_precision(json_t *json, double value, int precision) {
     if (!json_is_real(json) || isnan(value) || isinf(value))
         return -1;
 
     json_to_real(json)->value = value;
+    json_to_real(json)->precision = precision;
 
     return 0;
+}
+
+int json_real_set(json_t *json, double value) {
+    return(json_real_set_with_precision(json, value, DEFAULT_PRECISION_SYSTEM)); 
+}
+
+int json_real_set_precision(json_t *json, int precision) {
+    if (!json_is_real(json))
+        return -1;
+
+    json_to_real(json)->precision = precision;
+    return(0);
 }
 
 static void json_delete_real(json_real_t *real) { jsonp_free(real); }


### PR DESCRIPTION
Is this an acceptable approach for solving/getting control over the way floats/reals are formatted?
We would really appreciate if this patch could be admitted to the master.
