### PR TITLE
Use sprintf() to determine locale's decimal point

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,14 @@
+Version 2.14.1
+==============
+
+Work in progress
+
+* Fixes:
+
+  - Fix thread safety of encoding and decoding when `uselocale` or `newlocale`
+    is used to switch locales inside the threads (#674, #675, #677. Thanks to
+    Bruno Haible the report and help with fixing.)
+
 Version 2.14
 ============
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,18 +215,7 @@ if (NOT DEFINED JSON_INT_T)
    endif ()
 endif ()
 
-
-# If locale.h and localeconv() are available, define to 1, otherwise to 0.
 check_include_files (locale.h HAVE_LOCALE_H)
-check_function_exists (localeconv HAVE_LOCALECONV)
-
-if (HAVE_LOCALECONV AND HAVE_LOCALE_H)
-   set (JSON_HAVE_LOCALECONV 1)
-else ()
-   set (JSON_HAVE_LOCALECONV 0)
-endif()
-
-# check if we have setlocale
 check_function_exists(setlocale HAVE_SETLOCALE)
 
 # Check what the inline keyword is.

--- a/android/jansson_config.h
+++ b/android/jansson_config.h
@@ -32,10 +32,6 @@
    otherwise to 0. */
 #define JSON_INTEGER_IS_LONG_LONG 1
 
-/* If locale.h and localeconv() are available, define to 1,
-   otherwise to 0. */
-#define JSON_HAVE_LOCALECONV 0
-
 /* Maximum recursion depth for parsing JSON input.
    This limits the depth of e.g. array-within-array constructions. */
 #define JSON_PARSER_MAX_DEPTH 2048

--- a/cmake/jansson_config.h.cmake
+++ b/cmake/jansson_config.h.cmake
@@ -56,9 +56,6 @@
 #define JSON_INTEGER_FORMAT @JSON_INTEGER_FORMAT@
 
 
-/* If locale.h and localeconv() are available, define to 1, otherwise to 0. */
-#define JSON_HAVE_LOCALECONV @JSON_HAVE_LOCALECONV@
-
 /* If __atomic builtins are available they will be used to manage
    reference counts of json_t. */
 #define JSON_HAVE_ATOMIC_BUILTINS @JSON_HAVE_ATOMIC_BUILTINS@

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ esac
 AC_SUBST([json_inline])
 
 # Checks for library functions.
-AC_CHECK_FUNCS([close getpid gettimeofday localeconv open read sched_yield strtoll])
+AC_CHECK_FUNCS([close getpid gettimeofday open read setlocale sched_yield strtoll])
 
 AC_MSG_CHECKING([for gcc __sync builtins])
 have_sync_builtins=no
@@ -73,12 +73,6 @@ case "$ac_cv_type_long_long_int$ac_cv_func_strtoll" in
      *) json_have_long_long=0;;
 esac
 AC_SUBST([json_have_long_long])
-
-case "$ac_cv_header_locale_h$ac_cv_func_localeconv" in
-     yesyes) json_have_localeconv=1;;
-     *) json_have_localeconv=0;;
-esac
-AC_SUBST([json_have_localeconv])
 
 # Features
 AC_ARG_ENABLE([urandom],

--- a/src/jansson_config.h.in
+++ b/src/jansson_config.h.in
@@ -32,10 +32,6 @@
    otherwise to 0. */
 #define JSON_INTEGER_IS_LONG_LONG @json_have_long_long@
 
-/* If locale.h and localeconv() are available, define to 1,
-   otherwise to 0. */
-#define JSON_HAVE_LOCALECONV @json_have_localeconv@
-
 /* If __atomic builtins are available they will be used to manage
    reference counts of json_t. */
 #define JSON_HAVE_ATOMIC_BUILTINS @json_have_atomic_builtins@


### PR DESCRIPTION
This should fix thread safety of encoding and decoding, since localeconv() is not tread safe after all.