### PR TITLE
fixed cmake building soversion is diffrent with automake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,11 +314,19 @@ if(JANSSON_BUILD_SHARED_LIBS)
       set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--default-symver")
    else()
 # some linkers may only support --version-script
-      file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/jansson.sym" "JANSSON_${JANSSON_SOVERSION} {
+      if (UNIX)
+         file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/jansson.sym" "libjansson.so.${JANSSON_SOVERSION} {
     global:
           *;
 };
 ")
+      else ()
+         file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/jansson.sym" "JANSSON_${JANSSON_SOVERSION} {
+         global:
+               *;
+};
+")
+      endif ()    
       list(APPEND CMAKE_REQUIRED_LIBRARIES "-Wl,--version-script,${CMAKE_CURRENT_BINARY_DIR}/jansson.sym")
       check_c_source_compiles(
    "

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,10 @@ source distribution for details.
 Compilation and Installation
 ----------------------------
 
+Unix-like building system
+
+It supports Unix-like Operating System and MingW.
+
 If you obtained a ``jansson-X.Y.tar.*`` tarball from GitHub Releases, just use
 the standard autotools commands::
 
@@ -45,6 +49,20 @@ script has to be generated first. The easiest way is to use autoreconf::
 
    $ autoreconf -i
 
+Cmake building system
+
+It supports Windows, MacOS, Linux, Android and many other OS.
+
+   $ mkdir build && cd build
+   $ cmake ..
+   $ make
+
+To run the test suite, invoke::
+
+   $ ctest
+
+If you want to building the shared libraries, please add
+-DJANSSON_BUILD_SHARED_LIBS=ON
 
 Documentation
 -------------


### PR DESCRIPTION
OS: fedora 39
Architecture: x86_64

when I use automake to build jansson, the soversion symbol is
Version definitions:
1 0x01 0x0d1dca64 libjansson.so.4
2 0x00 0x0d1dca64 libjansson.so.4

but when I use cmake to build jansson, the soversion symbol is
Version definitions:
1 0x01 0x0d1dca64 libjansson.so.4
2 0x00 0x03888e44 JANSSON_4

you can use objdump -p libjansson.so.4.14.0 to see the infomation.
so I think it is necessary to modify the jansson.sym infomation to make soversion between automake and cmake same.