### PR TITLE
Refactor tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
           CC: ${{matrix.cc}}
         run: cmake .
       - run: cmake --build .
-      - run: ctest
+      - run: ctest --output-on-failure
 
   valgrind:
     runs-on: ubuntu-latest
@@ -63,4 +63,4 @@ jobs:
       - run: sudo apt update && sudo apt install valgrind
       - run: cmake -DJANSSON_TEST_WITH_VALGRIND=ON .
       - run: cmake --build .
-      - run: ctest
+      - run: ctest --output-on-failure

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,10 @@ Work in progress
     is used to switch locales inside the threads (#674, #675, #677. Thanks to
     Bruno Haible the report and help with fixing.)
 
+* Build:
+
+  - Make test output nicer in CMake based builds (#683)
+
 Version 2.14
 ============
 

--- a/scripts/clang-format
+++ b/scripts/clang-format
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-find . -type f -a '(' -name '*.c' -o -name '*.h' ')' | xargs clang-format -i
+git ls-files | grep '\.[ch]$' | xargs clang-format -i

--- a/scripts/clang-format-check
+++ b/scripts/clang-format-check
@@ -12,13 +12,16 @@ fi
 errors=0
 paths=$(git ls-files | grep '\.[ch]$')
 for path in $paths; do
+    echo "Checking $path"
+    $CLANG_FORMAT $path > $path.formatted
     in=$(cat $path)
-    out=$($CLANG_FORMAT $path)
+    out=$(cat $path.formatted)
 
     if [ "$in" != "$out" ]; then
-        diff -u -L $path -L "$path.formatted" $path - <<<$out
+        diff -u $path $path.formatted
         errors=1
     fi
+    rm $path.formatted
 done
 
 if [ $errors -ne 0 ]; then

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -7,6 +7,7 @@ suites/api/test_cpp
 suites/api/test_dump
 suites/api/test_dump_callback
 suites/api/test_equal
+suites/api/test_fixed_size
 suites/api/test_load
 suites/api/test_load_callback
 suites/api/test_loadb

--- a/test/suites/encoding-flags/run
+++ b/test/suites/encoding-flags/run
@@ -10,23 +10,13 @@ is_test() {
 }
 
 run_test() {
-    (
-        if [ -f $test_path/env ]; then
-            . $test_path/env
-        fi
-        $json_process --env <$test_path/input >$test_log/stdout 2>$test_log/stderr
-    )
+    $json_process $test_path >$test_log/stdout 2>$test_log/stderr || return 1
     valgrind_check $test_log/stderr || return 1
-    cmp -s $test_path/output $test_log/stdout
 }
 
 show_error() {
     valgrind_show_error && return
-
-    echo "EXPECTED OUTPUT:"
-    nl -bn $test_path/output
-    echo "ACTUAL OUTPUT:"
-    nl -bn $test_log/stdout
+    cat $test_log/stderr
 }
 
 . $top_srcdir/test/scripts/run-tests.sh

--- a/test/suites/invalid-unicode/run
+++ b/test/suites/invalid-unicode/run
@@ -10,18 +10,13 @@ is_test() {
 }
 
 run_test() {
-    $json_process --env <$test_path/input >$test_log/stdout 2>$test_log/stderr
-    valgrind_check $test_log/stderr || return 1
-    cmp -s $test_path/error $test_log/stderr
+    $json_process $test_path >$test_log/stdout 2>$test_log/stderr || return 1
+    valgrind_check $test_log/stderr$s || return 1
 }
 
 show_error() {
     valgrind_show_error && return
-
-    echo "EXPECTED ERROR:"
-    nl -bn $test_path/error
-    echo "ACTUAL ERROR:"
-    nl -bn $test_log/stderr
+    cat $test_log/stderr
 }
 
 . $top_srcdir/test/scripts/run-tests.sh

--- a/test/suites/invalid/run
+++ b/test/suites/invalid/run
@@ -13,24 +13,18 @@ do_run() {
     variant=$1
     s=".$1"
 
-    strip=0
+    strip=""
     if [ "$variant" = "strip" ]; then
         # This test should not be stripped
         [ -f $test_path/nostrip ] && return
-        strip=1
+        strip="--strip"
     fi
 
-    STRIP=$strip $json_process --env \
-        <$test_path/input >$test_log/stdout$s 2>$test_log/stderr$s
-    valgrind_check $test_log/stderr$s || return 1
-
-    ref=error
-    [ -f $test_path/error$s ] && ref=error$s
-
-    if ! cmp -s $test_path/$ref $test_log/stderr$s; then
-        echo $variant > $test_log/variant
+    if ! $json_process $strip $test_path >$test_log/stdout$s 2>$test_log/stderr$s; then
+        echo $variant >$test_log/variant
         return 1
     fi
+    valgrind_check $test_log/stderr$s || return 1
 }
 
 run_test() {
@@ -44,14 +38,7 @@ show_error() {
     s=".$variant"
 
     echo "VARIANT: $variant"
-
-    echo "EXPECTED ERROR:"
-    ref=error
-    [ -f $test_path/error$s ] && ref=error$s
-    nl -bn $test_path/$ref
-
-    echo "ACTUAL ERROR:"
-    nl -bn $test_log/stderr$s
+    cat $test_log/stderr$s
 }
 
 . $top_srcdir/test/scripts/run-tests.sh

--- a/test/suites/valid/run
+++ b/test/suites/valid/run
@@ -16,20 +16,14 @@ do_run() {
     variant=$1
     s=".$1"
 
-    strip=0
-    [ "$variant" = "strip" ] && strip=1
+    strip=""
+    [ "$variant" = "strip" ] && strip="--strip"
 
-    STRIP=$strip $json_process --env \
-        <$test_path/input >$test_log/stdout$s 2>$test_log/stderr$s
-    valgrind_check $test_log/stderr$s || return 1
-
-    ref=output
-    [ -f $test_path/output$s ] && ref=output$s
-
-    if ! cmp -s $test_path/$ref $test_log/stdout$s; then
-        echo $variant > $test_log/variant
+    if ! $json_process $strip $test_path >$test_log/stdout$s 2>$test_log/stderr$s; then
+        echo $variant >$test_log/variant
         return 1
     fi
+    valgrind_check $test_log/stderr$s || return 1
 }
 
 run_test() {
@@ -43,14 +37,7 @@ show_error() {
     s=".$variant"
 
     echo "VARIANT: $variant"
-
-    echo "EXPECTED OUTPUT:"
-    ref=output
-    [ -f $test_path/output$s ] && ref=output$s
-    nl -bn $test_path/$ref
-
-    echo "ACTUAL OUTPUT:"
-    nl -bn $test_log/stdout$s
+    cat $test_log/stderr$s
 }
 
 . $top_srcdir/test/scripts/run-tests.sh


### PR DESCRIPTION
Move some basic functionality from shell scripts to `json_process.c` to make test output better in CMake builds. This also removes a lot of redundancy in the code.

While at it, also improve the output of `clang-format` scripts.