### PR TITLE
add autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,1 @@
+autoreconf -v -i


### PR DESCRIPTION
Some build systems (like flatpak) are
clueless. They need `autogen.sh` or `configure`
to proceed.