### PR TITLE
Use target-based cmake settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.5)
 project(jansson C)
 
 # Options
@@ -266,17 +266,14 @@ configure_file (${CMAKE_CURRENT_SOURCE_DIR}/cmake/jansson_config.h.cmake
 file (COPY ${CMAKE_CURRENT_SOURCE_DIR}/src/jansson.h
            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include/)
 
-add_definitions(-DJANSSON_USING_CMAKE)
-
 # configure the private config file
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/cmake/jansson_private_config.h.cmake
                 ${CMAKE_CURRENT_BINARY_DIR}/private_include/jansson_private_config.h)
 
-# and tell the source code to include it
-add_definitions(-DHAVE_CONFIG_H)
-
-include_directories (${CMAKE_CURRENT_BINARY_DIR}/include)
 include_directories (${CMAKE_CURRENT_BINARY_DIR}/private_include)
+
+# Configuration flags will be set on project later once we have defined the target
+
 
 # Add the lib sources.
 file(GLOB JANSSON_SRC src/*.c)
@@ -355,6 +352,20 @@ else()
    set_target_properties(jansson PROPERTIES
       POSITION_INDEPENDENT_CODE true)
 endif()
+
+
+# Now target jansson is declared, set per-target values
+
+target_compile_definitions(jansson PUBLIC JANSSON_USING_CMAKE)
+target_compile_definitions(jansson PRIVATE HAVE_CONFIG_H)
+
+target_include_directories(jansson
+	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+	INTERFACE $<INSTALL_INTERFACE:include>
+)
+
+add_library( jansson::jansson ALIAS jansson )
+
 
 if (JANSSON_EXAMPLES)
 	add_executable(simple_parse "${CMAKE_CURRENT_SOURCE_DIR}/examples/simple_parse.c")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.10)
 project(jansson C)
 
 # Options


### PR DESCRIPTION
- Update minimum required to CMake version 3.5 (versions older than 3.5 are deprecated as of 3.27)
- update add_definitions to target_compile_definitions
- use target_include_directories for public library includes
- add jansson::jansson alias

This addresses comments in https://github.com/akheron/jansson/pull/664 .  It deprecates that request.