### PR TITLE
Avoid warnings during build on several compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,12 @@ if (NOT DEFINED JSON_INT_T)
    endif ()
 endif ()
 
+if (WIN32) # matches both msvc and cygwin
+   set (JSON_LONG_LONG_FORMAT "\"I64d\"")
+else ()
+   set (JSON_LONG_LONG_FORMAT "\"lld\"")
+endif ()
+
 check_include_files (locale.h HAVE_LOCALE_H)
 check_function_exists(setlocale HAVE_SETLOCALE)
 

--- a/cmake/jansson_config.h.cmake
+++ b/cmake/jansson_config.h.cmake
@@ -55,6 +55,7 @@
 #define json_int_t @JSON_INT_T@
 #define json_strtoint @JSON_STRTOINT@
 #define JSON_INTEGER_FORMAT @JSON_INTEGER_FORMAT@
+#define JSON_LONG_LONG_FORMAT @JSON_LONG_LONG_FORMAT@
 
 
 /* If __atomic builtins are available they will be used to manage

--- a/examples/simple_parse.c
+++ b/examples/simple_parse.c
@@ -26,6 +26,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifndef JANSSON_USING_CMAKE /* disabled if using cmake */
+#ifdef _WIN32
+#define JSON_LONG_LONG_FORMAT "I64d"
+#else
+#define JSON_LONG_LONG_FORMAT "lld"
+#endif
+#endif
+
 /* forward refs */
 void print_json(json_t *root);
 void print_json_aux(json_t *element, int indent);
@@ -90,7 +98,7 @@ void print_json_object(json_t *element, int indent) {
     print_json_indent(indent);
     size = json_object_size(element);
 
-    printf("JSON Object of %lld pair%s:\n", (long long)size, json_plural(size));
+    printf("JSON Object of %" JSON_LONG_LONG_FORMAT " pair%s:\n", (long long)size, json_plural(size));
     json_object_foreach(element, key, value) {
         print_json_indent(indent + 2);
         printf("JSON Key: \"%s\"\n", key);
@@ -103,7 +111,7 @@ void print_json_array(json_t *element, int indent) {
     size_t size = json_array_size(element);
     print_json_indent(indent);
 
-    printf("JSON Array of %lld element%s:\n", (long long)size, json_plural(size));
+    printf("JSON Array of %" JSON_LONG_LONG_FORMAT " element%s:\n", (long long)size, json_plural(size));
     for (i = 0; i < size; i++) {
         print_json_aux(json_array_get(element, i), indent + 2);
     }

--- a/src/dtoa.c
+++ b/src/dtoa.c
@@ -3497,7 +3497,7 @@ strtod__unused(const char *s00, char **se)
 	U aadj2, adj, rv, rv0;
 	ULong y, z;
 	BCinfo bc;
-	Bigint *bb, *bb1, *bd, *bd0, *bs, *delta;
+	Bigint *bb = NULL, *bb1, *bd = NULL, *bd0, *bs = NULL, *delta = NULL;
 #ifdef USE_BF96
 	ULLong bhi, blo, brv, t00, t01, t02, t10, t11, terv, tg, tlo, yz;
 	const BF96 *p10;
@@ -5072,7 +5072,7 @@ dtoa_r(double dd, int mode, int ndigits, int *decpt, int *sign, char **rve, char
 #ifdef USE_BF96 /*{{*/
 	BF96 *p10;
 	ULLong dbhi, dbits, dblo, den, hb, rb, rblo, res, res0, res3, reslo, sres,
-		sulp, tv0, tv1, tv2, tv3, ulp, ulplo, ulpmask, ures, ureslo, zb;
+		sulp, tv0, tv1, tv2, tv3, ulp, ulplo, ulpmask = 0, ures, ureslo, zb;
 	int eulp, k1, n2, ulpadj, ulpshift;
 #else /*}{*/
 #ifndef Sudden_Underflow

--- a/src/error.c
+++ b/src/error.c
@@ -22,7 +22,7 @@ void jsonp_error_set_source(json_error_t *error, const char *source) {
 
     length = strlen(source);
     if (length < JSON_ERROR_SOURCE_LENGTH)
-        strncpy(error->source, source, length + 1);
+        memcpy(error->source, source, length + 1);
     else {
         size_t extra = length - JSON_ERROR_SOURCE_LENGTH + 4;
         memcpy(error->source, "...", 3);


### PR DESCRIPTION
Current Release build of jansson's `master` produces some warnings on several compilers, namely gcc 6.x, gcc 10.x, and lcc (eLbrus C/C++ compiler) 1.25 and 1.26. In addition, it uses incorrect format conversions on `WIN32` in a couple places.

This PR fixes all this issues.

On each of my setups (different CPU arches, compilers, OS, etc.) both Release and Debug builds are now warningless, and all CTest tests pass successfully.