### PR TITLE
Compiler warning -Werror=stringop-truncation fix for error.c

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -22,7 +22,7 @@ void jsonp_error_set_source(json_error_t *error, const char *source) {
 
     length = strlen(source);
     if (length < JSON_ERROR_SOURCE_LENGTH)
-        strncpy(error->source, source, length + 1);
+        strncpy(error->source, source, JSON_ERROR_SOURCE_LENGTH);
     else {
         size_t extra = length - JSON_ERROR_SOURCE_LENGTH + 4;
         memcpy(error->source, "...", 3);


### PR DESCRIPTION
Hi. This warning is emitted by newer versions of gcc. The project I'm working with treats this particular warning as an error.
The fix below makes the compiler happy.

The full error message emitted looks like this:
```
| jansson/src/error.c: In function 'jsonp_error_set_source':
| jansson/src/error.c:25:9: error: '__builtin_strncpy' specified bound depends on the length of the source argument [-Werror=stringop-truncation]
|    25 |         strncpy(error->source, source, length + 1);
|       |         ^
| In function 'jsonp_error_set_source',
| jansson/src/error.c:17:6:
| jansson/src/error.c:23:14: note: length computed here
|    23 |     length = strlen(source);
|       |              ^~~~~~~~~~~~~~
| cc1: all warnings being treated as errors
```

Thank you.
--Steve