### PR TITLE
Provide better typed json_typeof

### DIFF
--- a/src/jansson.h
+++ b/src/jansson.h
@@ -78,6 +78,10 @@ typedef long json_int_t;
 #endif
 
 #define json_typeof(json)     ((json)->type)
+static JSON_INLINE enum json_type json_type(const json_t *json) {
+   return (enum json_type)json->type;
+}
+
 #define json_is_object(json)  ((json) && json_typeof(json) == JSON_OBJECT)
 #define json_is_array(json)   ((json) && json_typeof(json) == JSON_ARRAY)
 #define json_is_string(json)  ((json) && json_typeof(json) == JSON_STRING)


### PR DESCRIPTION
Further down in the header the function `json_error_code()` is defined to return the `enum json_error_code`.

That function has a much better documentation value, as it also defines what values the returned value can have.

It also sets a naming precedent, of having a function of the same name as the enum, which makes a lot of sense to me.

In the future, when you bump the major version of the library anyway, you could change the define of json_typeof to

`#define json_typeof json_type`

and maybe start a deprecation cycle of the old name.

What do you think? Would that be a good patch?