### PR TITLE
Only export symbols starting with "json_" and "jansson_" for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,9 @@ if(JANSSON_BUILD_SHARED_LIBS)
 # some linkers may only support --version-script
       file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/jansson.sym" "JANSSON_${JANSSON_SOVERSION} {
     global:
+          json_*;
+          jansson_*;
+    local:
           *;
 };
 ")


### PR DESCRIPTION
It's already done by the commit 7c707a7 and bcb6b6f, but not for cmake. This makes symbols in the same visibility as built with libtool.