### PR TITLE
include jansson_private_config.h only if HAVE_CONFIG_H is enabled

### DIFF
--- a/src/jansson_private.h
+++ b/src/jansson_private.h
@@ -10,7 +10,9 @@
 
 #include "hashtable.h"
 #include "jansson.h"
+#ifdef HAVE_CONFIG_H
 #include "jansson_private_config.h"
+#endif
 #include "strbuffer.h"
 #include <stddef.h>
 


### PR DESCRIPTION
even if HAVE_CONFIG_H was not enabled, jansson_private_config.h was getting included.