### PR TITLE
Unpack: report presence of optional object items

### DIFF
--- a/doc/apiref.rst
+++ b/doc/apiref.rst
@@ -1748,6 +1748,12 @@ type whose address should be passed.
        make the key optional. If the key is not found, nothing is
        extracted. See below for an example.
 
+    .. versionadded:: 2.16
+       Any ``s`` representing a key may be suffixed with a ``*`` to
+       make the key optional. An additional :type:`int*` argument is
+       consumed and its value is set to 1 if the key is found and to
+       0 if the key is not found. See below for an example.
+
 ``!``
     This special format specifier is used to enable the check that
     all object and array items are accessed, on a per-value basis. It
@@ -1834,6 +1840,14 @@ Examples::
                 "foo", &myint1,
                 "bar", &myint2, &myint3);
     /* myint1, myint2 or myint3 is no touched as "foo" and "bar" don't exist */
+
+    /* root is the JSON object {"foo": 42} */
+    int myint = 0, myint2 = 0, myint3 = 0;
+    int have_foo, have_bar;
+    json_unpack(root, "{s*i, s*[ii]}",
+                "foo", &have_foo, &myint1,
+                "bar", &have_bar, &myint2, &myint3);
+    assert(have_foo == 1 && have_bar == 0 && myint1 == 42);
 
 
 Equality

--- a/src/pack_unpack.c
+++ b/src/pack_unpack.c
@@ -491,6 +491,7 @@ static int unpack_object(scanner_t *s, json_t *root, va_list *ap) {
         size_t key_len;
         json_t *value;
         int opt = 0;
+        int *presence = NULL;
 
         if (strict != 0) {
             set_error(s, "<format>", json_error_invalid_format,
@@ -529,6 +530,10 @@ static int unpack_object(scanner_t *s, json_t *root, va_list *ap) {
         if (token(s) == '?') {
             opt = gotopt = 1;
             next_token(s);
+        } else if (token(s) == '*') {
+            opt = gotopt = 1;
+            next_token(s);
+            presence = va_arg(*ap, int *);
         }
 
         if (!root) {
@@ -536,6 +541,9 @@ static int unpack_object(scanner_t *s, json_t *root, va_list *ap) {
             value = NULL;
         } else {
             value = json_object_getn(root, key, key_len);
+            if (presence) {
+                *presence = (value != NULL);
+            }
             if (!value && !opt) {
                 set_error(s, "<validation>", json_error_item_not_found,
                           "Object item not found: %s", key);

--- a/test/suites/api/test_unpack.c
+++ b/test/suites/api/test_unpack.c
@@ -385,12 +385,34 @@ static void run_tests() {
         fail("json_unpack unpacked an optional key");
     json_decref(j);
 
+    j = json_object();
+    i1 = 0;
+    i2 = -1;
+    if (json_unpack(j, "{s*i}", "foo", &i2, &i1))
+        fail("json_unpack failed for absent optional key");
+    if (i1 != 0)
+        fail("json_unpack unpacked an absent optional key");
+    if (i2 != 0)
+        fail("json_unpack misreported absence of optional key");
+    json_decref(j);
+
     i1 = 0;
     j = json_pack("{si}", "foo", 42);
     if (json_unpack(j, "{s?i}", "foo", &i1))
         fail("json_unpack failed for an optional value");
     if (i1 != 42)
         fail("json_unpack failed to unpack an optional value");
+    json_decref(j);
+
+    i1 = 0;
+    i2 = -1;
+    j = json_pack("{si}", "foo", 42);
+    if (json_unpack(j, "{s*i}", "foo", &i2, &i1))
+        fail("json_unpack failed for a present optional value");
+    if (i1 != 42)
+        fail("json_unpack failed to unpack a present optional value");
+    if (i2 != 1)
+        fail("json_unpack misreported presence of optional value");
     json_decref(j);
 
     j = json_object();


### PR DESCRIPTION
Implements #67 (slightly differently).

I have recently had a need to have `json_unpack` reliably report whether optional keys in an object are present or not, also for types that don’t have a natural null value, such as integers. This has already been discussed (and postponed) years ago in #67, so I figured it was time to implement it. I did it in a similar but not exactly the same way as sketched there, one that I think is more consistent and simpler to implement:

- Like in [#67](https://github.com/akheron/jansson/issues/67), the requested information is returned through additional `int*` arguments read from the variable argument list.
- Unlike in [#67](https://github.com/akheron/jansson/issues/67), for consistency with the existing `s?` that marks a key as optional (without presence reporting), the newly introduced format modifier comes after the key, not after the value. Accordingly, the `int*` argument for the presence output comes before the pointer argument for the value output, to match the order of format characters.
- Unlike in [#67](https://github.com/akheron/jansson/issues/67), for consistency with the `s*` or `o*` that makes an item optional in `json_pack`, the newly introduced format modifier is `*`. `?` as proposed in [#67](https://github.com/akheron/jansson/issues/67) is already taken by optionality without presence reporting, and it means “`null` if absent” in `json_pack`, which is less closely related. There is no ambiguity with the `*` that means not-`JSON_STRICT` in an object, because the latter always comes after a value, while this one always comes after a key. However, if this is still considered confusing, a different character than `*` could be chosen (maybe `@`?).

Summarized in an example (see also the documentation addition):

```c
json_t *root = …;
int foo_value = -1;
int have_foo;

// existing optionality without presence reporting:
json_unpack(root, "{s?i}", "foo", &foo_value);
// can't tell whether foo_value == -1 means foo was absent or was literal -1

// new optionality with presence reporting:
json_unpack(root, "{s*i}", "foo", &have_foo, &foo_value);
if (have_foo) {
    // present, stored in foo_value
} else {
    // absent, foo_value untouched
}
```

What do you think?