### PR TITLE
Unpack: include keys in type mismatch error messages

### DIFF
--- a/src/pack_unpack.c
+++ b/src/pack_unpack.c
@@ -460,9 +460,10 @@ static json_t *pack(scanner_t *s, va_list *ap) {
     }
 }
 
-static int unpack(scanner_t *s, json_t *root, va_list *ap);
+static int unpack(scanner_t *s, json_t *root, va_list *ap, const char *key);
 
-static int unpack_object(scanner_t *s, json_t *root, va_list *ap) {
+static int unpack_object(scanner_t *s, json_t *root, va_list *ap,
+                         const char *parent_key) {
     int ret = -1;
     int strict = 0;
     int gotopt = 0;
@@ -480,8 +481,9 @@ static int unpack_object(scanner_t *s, json_t *root, va_list *ap) {
     }
 
     if (root && !json_is_object(root)) {
-        set_error(s, "<validation>", json_error_wrong_type, "Expected object, got %s",
-                  type_name(root));
+        set_error(s, "<validation>", json_error_wrong_type, "Expected object, got %s%s%s",
+                  type_name(root), parent_key ? " for key " : "",
+                  parent_key ? parent_key : "");
         goto out;
     }
     next_token(s);
@@ -543,7 +545,7 @@ static int unpack_object(scanner_t *s, json_t *root, va_list *ap) {
             }
         }
 
-        if (unpack(s, value, ap))
+        if (unpack(s, value, ap, key))
             goto out;
 
         hashtable_set(&key_set, key, key_len, json_null());
@@ -597,13 +599,14 @@ out:
     return ret;
 }
 
-static int unpack_array(scanner_t *s, json_t *root, va_list *ap) {
+static int unpack_array(scanner_t *s, json_t *root, va_list *ap, const char *parent_key) {
     size_t i = 0;
     int strict = 0;
 
     if (root && !json_is_array(root)) {
-        set_error(s, "<validation>", json_error_wrong_type, "Expected array, got %s",
-                  type_name(root));
+        set_error(s, "<validation>", json_error_wrong_type, "Expected array, got %s%s%s",
+                  type_name(root), parent_key ? " for key " : "",
+                  parent_key ? parent_key : "");
         return -1;
     }
     next_token(s);
@@ -648,7 +651,7 @@ static int unpack_array(scanner_t *s, json_t *root, va_list *ap) {
             }
         }
 
-        if (unpack(s, value, ap))
+        if (unpack(s, value, ap, NULL))
             return -1;
 
         next_token(s);
@@ -668,18 +671,19 @@ static int unpack_array(scanner_t *s, json_t *root, va_list *ap) {
     return 0;
 }
 
-static int unpack(scanner_t *s, json_t *root, va_list *ap) {
+static int unpack(scanner_t *s, json_t *root, va_list *ap, const char *key) {
     switch (token(s)) {
         case '{':
-            return unpack_object(s, root, ap);
+            return unpack_object(s, root, ap, key);
 
         case '[':
-            return unpack_array(s, root, ap);
+            return unpack_array(s, root, ap, key);
 
         case 's':
             if (root && !json_is_string(root)) {
                 set_error(s, "<validation>", json_error_wrong_type,
-                          "Expected string, got %s", type_name(root));
+                          "Expected string, got %s%s%s", type_name(root),
+                          key ? " for key " : "", key ? key : "");
                 return -1;
             }
 
@@ -716,7 +720,8 @@ static int unpack(scanner_t *s, json_t *root, va_list *ap) {
         case 'i':
             if (root && !json_is_integer(root)) {
                 set_error(s, "<validation>", json_error_wrong_type,
-                          "Expected integer, got %s", type_name(root));
+                          "Expected integer, got %s%s%s", type_name(root),
+                          key ? " for key " : "", key ? key : "");
                 return -1;
             }
 
@@ -731,7 +736,8 @@ static int unpack(scanner_t *s, json_t *root, va_list *ap) {
         case 'I':
             if (root && !json_is_integer(root)) {
                 set_error(s, "<validation>", json_error_wrong_type,
-                          "Expected integer, got %s", type_name(root));
+                          "Expected integer, got %s%s%s", type_name(root),
+                          key ? " for key " : "", key ? key : "");
                 return -1;
             }
 
@@ -746,7 +752,8 @@ static int unpack(scanner_t *s, json_t *root, va_list *ap) {
         case 'b':
             if (root && !json_is_boolean(root)) {
                 set_error(s, "<validation>", json_error_wrong_type,
-                          "Expected true or false, got %s", type_name(root));
+                          "Expected true or false, got %s%s%s", type_name(root),
+                          key ? " for key " : "", key ? key : "");
                 return -1;
             }
 
@@ -761,7 +768,8 @@ static int unpack(scanner_t *s, json_t *root, va_list *ap) {
         case 'f':
             if (root && !json_is_real(root)) {
                 set_error(s, "<validation>", json_error_wrong_type,
-                          "Expected real, got %s", type_name(root));
+                          "Expected real, got %s%s%s", type_name(root),
+                          key ? " for key " : "", key ? key : "");
                 return -1;
             }
 
@@ -776,7 +784,8 @@ static int unpack(scanner_t *s, json_t *root, va_list *ap) {
         case 'F':
             if (root && !json_is_number(root)) {
                 set_error(s, "<validation>", json_error_wrong_type,
-                          "Expected real or integer, got %s", type_name(root));
+                          "Expected real or integer, got %s%s%s", type_name(root),
+                          key ? " for key " : "", key ? key : "");
                 return -1;
             }
 
@@ -806,7 +815,8 @@ static int unpack(scanner_t *s, json_t *root, va_list *ap) {
             /* Never assign, just validate */
             if (root && !json_is_null(root)) {
                 set_error(s, "<validation>", json_error_wrong_type,
-                          "Expected null, got %s", type_name(root));
+                          "Expected null, got %s%s%s", type_name(root),
+                          key ? " for key " : "", key ? key : "");
                 return -1;
             }
             return 0;
@@ -898,7 +908,7 @@ int json_vunpack_ex(json_t *root, json_error_t *error, size_t flags, const char 
     next_token(&s);
 
     va_copy(ap_copy, ap);
-    if (unpack(&s, root, &ap_copy)) {
+    if (unpack(&s, root, &ap_copy, NULL)) {
         va_end(ap_copy);
         return -1;
     }

--- a/test/suites/api/test_unpack.c
+++ b/test/suites/api/test_unpack.c
@@ -263,6 +263,57 @@ static void run_tests() {
     json_decref(j);
     json_decref(j2);
 
+    /* invalid types in objects */
+    j = json_pack("{si}", "bar", 42);
+    j2 = json_pack("{ss}", "bar", "foo");
+    if (!json_unpack_ex(j, &error, 0, "{ss}", "bar"))
+        fail("json_unpack failed to catch invalid type in object");
+    check_error(json_error_wrong_type, "Expected string, got integer for key bar",
+                "<validation>", 1, 3, 3);
+
+    if (!json_unpack_ex(j, &error, 0, "{sn}", "bar"))
+        fail("json_unpack failed to catch invalid type in object");
+    check_error(json_error_wrong_type, "Expected null, got integer for key bar",
+                "<validation>", 1, 3, 3);
+
+    if (!json_unpack_ex(j, &error, 0, "{sb}", "bar"))
+        fail("json_unpack failed to catch invalid type in object");
+    check_error(json_error_wrong_type, "Expected true or false, got integer for key bar",
+                "<validation>", 1, 3, 3);
+
+    if (!json_unpack_ex(j2, &error, 0, "{si}", "bar"))
+        fail("json_unpack failed to catch invalid type in object");
+    check_error(json_error_wrong_type, "Expected integer, got string for key bar",
+                "<validation>", 1, 3, 3);
+
+    if (!json_unpack_ex(j2, &error, 0, "{sI}", "bar"))
+        fail("json_unpack failed to catch invalid type in object");
+    check_error(json_error_wrong_type, "Expected integer, got string for key bar",
+                "<validation>", 1, 3, 3);
+
+    if (!json_unpack_ex(j, &error, 0, "{sf}", "bar"))
+        fail("json_unpack failed to catch invalid type in object");
+    check_error(json_error_wrong_type, "Expected real, got integer for key bar",
+                "<validation>", 1, 3, 3);
+
+    if (!json_unpack_ex(j2, &error, 0, "{sF}", "bar"))
+        fail("json_unpack failed to catch invalid type in object");
+    check_error(json_error_wrong_type, "Expected real or integer, got string for key bar",
+                "<validation>", 1, 3, 3);
+
+    if (!json_unpack_ex(j, &error, 0, "{s[i]}", "bar"))
+        fail("json_unpack failed to catch invalid type in object");
+    check_error(json_error_wrong_type, "Expected array, got integer for key bar",
+                "<validation>", 1, 3, 3);
+
+    if (!json_unpack_ex(j, &error, 0, "{s{si}}", "bar", "foo"))
+        fail("json_unpack failed to catch invalid type in object");
+    check_error(json_error_wrong_type, "Expected object, got integer for key bar",
+                "<validation>", 1, 3, 3);
+
+    json_decref(j);
+    json_decref(j2);
+
     /* Array index out of range */
     j = json_pack("[i]", 1);
     if (!json_unpack_ex(j, &error, 0, "[ii]", &i1, &i2))


### PR DESCRIPTION
I think the error messages like `Expected string, got integer` that `json_unpack_ex` outputs when parsing a JSON object like `{"one": 1, "two": 2, "three": 3}` would be much more helpful if they included information about _which_ item it was that was found problematic – just like the error message for a missing item already does: `Object item not found: four`.

The attached commit is a proposal how this could be implemented: it now says `Expected string, got integer for key two`. For values that are not in an object, but in an array or at the root level, the error message is unmodified as before.

This is not a full path in the case of nested objects, just the key in the innermost object, however I think that will be sufficient to guide a user in most cases. In cases where it is not, the calling code can still determine the full path by examining `error.position` (which points at the corresponding format specifier in the format string).

If changing error messages for existing callers is considered an incompatible API change, then this functionality could also be gated behind an additional flag for `json_unpack_ex`.

What do you think?