### PR TITLE
Make type names public

### DIFF
--- a/doc/apiref.rst
+++ b/doc/apiref.rst
@@ -178,6 +178,14 @@ Type
 
    .. versionadded:: 2.7
 
+.. function:: const char *json_type_name(json_type type)
+
+   Returns a string describing a JSON type, for error messages or the
+   like. The returned pointer refers to a string literal and stays
+   valid forever.
+
+   .. versionadded:: 2.16
+
 
 .. _apiref-reference-count:
 

--- a/src/jansson.def
+++ b/src/jansson.def
@@ -76,6 +76,7 @@ EXPORTS
     json_unpack
     json_unpack_ex
     json_vunpack_ex
+    json_type_name
     json_set_alloc_funcs
     json_set_alloc_funcs2
     json_get_alloc_funcs

--- a/src/jansson.h
+++ b/src/jansson.h
@@ -90,6 +90,8 @@ typedef long json_int_t;
 #define json_is_boolean(json) (json_is_true(json) || json_is_false(json))
 #define json_is_null(json)    ((json) && json_typeof(json) == JSON_NULL)
 
+const char *json_type_name(json_type type);
+
 /* construction, destruction, reference counting */
 
 json_t *json_object(void);

--- a/src/pack_unpack.c
+++ b/src/pack_unpack.c
@@ -936,3 +936,10 @@ int json_unpack(json_t *root, const char *fmt, ...) {
 
     return ret;
 }
+
+const char *json_type_name(json_type type) {
+    if (type < 0 || type >= sizeof(type_names) / sizeof(type_names[0]))
+        return "unknown";
+    else
+        return type_names[type];
+}

--- a/test/suites/api/test_simple.c
+++ b/test/suites/api/test_simple.c
@@ -283,5 +283,14 @@ static void run_tests() {
     json_decref(value);
 #endif
 
+    if (strcmp(json_type_name(JSON_OBJECT), "object"))
+        fail("unexpected type name for object");
+    if (strcmp(json_type_name(JSON_NULL), "null"))
+        fail("unexpected type name for null");
+    if (strcmp(json_type_name(-1), "unknown"))
+        fail("unexpected type name for invalid type");
+    if (strcmp(json_type_name(JSON_NULL + 1), "unknown"))
+        fail("unexpected type name for invalid type");
+
     test_bad_args();
 }


### PR DESCRIPTION
I recently needed to parse and validate some JSON objects using `json_unpack_ex`, however some parts of those objects have more complicated validity constraints than `json_unpack_ex` can express, so I need to do that part of the validation myself afterwards. Example: for a certain object key, I want to accept either an integer or a string containing the hexadecimal representation of an integer.

For the simple type constraints that `json_unpack_ex` can express, it already provides useful error messages like `Expected integer, got real`. For my own additional validation, I would like to give error messages in the same style: `Expected integer or string, got real`. Problem: while I can get the type of the actual value as a symbolic constant `JSON_REAL`, Jansson provides no way to convert that to the string `"real"` for my error message. The function (macro) `type_name()` that is internally used by `json_unpack_ex` for that purpose is not exposed in the API. So all I can do is either keep my own table of type names, which is duplication and fragile in the case that types are ever reordered or extended in Jansson, or call `json_unpack_ex` again with the value I have and a deliberately mismatched format for it, and dissect the error message it returns, which is a hassle.

The attached commit proposes fixing that by adding a new API function `const char *json_type_name(json_type type)` that provides (overrun-safe) access to Jansson’s internal type name table.