### PR TITLE
use bits for type to improve type checking performance

### DIFF
--- a/src/jansson.h
+++ b/src/jansson.h
@@ -48,14 +48,14 @@ extern "C" {
 /* types */
 
 typedef enum {
-    JSON_OBJECT,
-    JSON_ARRAY,
-    JSON_STRING,
-    JSON_INTEGER,
-    JSON_REAL,
-    JSON_TRUE,
-    JSON_FALSE,
-    JSON_NULL
+    JSON_OBJECT = 0x01,
+    JSON_ARRAY = 0x02,
+    JSON_STRING = 0x04,
+    JSON_INTEGER = 0x08,
+    JSON_REAL = 0x10,
+    JSON_TRUE = 0x20,
+    JSON_FALSE = 0x40,
+    JSON_NULL = 0x80
 } json_type;
 
 typedef struct json_t {
@@ -83,11 +83,11 @@ typedef long json_int_t;
 #define json_is_string(json)  ((json) && json_typeof(json) == JSON_STRING)
 #define json_is_integer(json) ((json) && json_typeof(json) == JSON_INTEGER)
 #define json_is_real(json)    ((json) && json_typeof(json) == JSON_REAL)
-#define json_is_number(json)  (json_is_integer(json) || json_is_real(json))
+#define json_is_number(json)  ((json) && (json_typeof(json) & (JSON_REAL | JSON_INTEGER)))
 #define json_is_true(json)    ((json) && json_typeof(json) == JSON_TRUE)
 #define json_is_false(json)   ((json) && json_typeof(json) == JSON_FALSE)
 #define json_boolean_value    json_is_true
-#define json_is_boolean(json) (json_is_true(json) || json_is_false(json))
+#define json_is_boolean(json) ((json) && (json_typeof(json) & (JSON_TRUE | JSON_FALSE)))
 #define json_is_null(json)    ((json) && json_typeof(json) == JSON_NULL)
 
 /* construction, destruction, reference counting */

--- a/src/pack_unpack.c
+++ b/src/pack_unpack.c
@@ -34,10 +34,28 @@ typedef struct {
 
 #define token(scanner) ((scanner)->token.token)
 
-static const char *const type_names[] = {"object", "array", "string", "integer",
-                                         "real",   "true",  "false",  "null"};
-
-#define type_name(x) type_names[json_typeof(x)]
+static const char *type_name(const json_t *j) {
+    switch (json_typeof(j)) {
+        case JSON_OBJECT:
+            return "object";
+        case JSON_ARRAY:
+            return "array";
+        case JSON_STRING:
+            return "string";
+        case JSON_INTEGER:
+            return "integer";
+        case JSON_REAL:
+            return "real";
+        case JSON_TRUE:
+            return "true";
+        case JSON_FALSE:
+            return "false";
+        case JSON_NULL:
+            return "null";
+        default:
+            return "<unexpected type>";
+    }
+}
 
 static const char unpack_value_starters[] = "{[siIbfFOon";
 


### PR DESCRIPTION
When checking JSON structures the type macros are used and can represent a significant execution time, especially if there is an implicit branch (`json_is_number` and `json_is_boolean`).

This patch uses bits instead of integer values to remove one branch and improve performance.
