### PR TITLE
load.c: stop silently dropping lex_save() OOM failures

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -68,6 +68,13 @@ typedef struct {
     size_t flags;
     size_t depth;
     int token;
+    /* Set when strbuffer_append_byte() fails inside lex_save(). The
+     * lexer continues forward (lex_save() is void-returning so the
+     * existing call sites cannot react), so we record the failure here
+     * and have the next lex_get_save() / lex_save_cached() turn it into
+     * a clean json_error_out_of_memory rather than a silently corrupt
+     * saved_text. */
+    int saved_text_oom;
     union {
         struct {
             char *val;
@@ -227,12 +234,26 @@ static int lex_get(lex_t *lex, json_error_t *error) {
     return stream_get(&lex->stream, error);
 }
 
-static void lex_save(lex_t *lex, int c) { strbuffer_append_byte(&lex->saved_text, c); }
+static void lex_save(lex_t *lex, int c) {
+    /* strbuffer_append_byte() returns -1 on allocation failure but
+     * lex_save() is void to keep the existing call sites simple. We
+     * record the failure on the lex_t so the next save-aware step
+     * (lex_get_save / lex_save_cached / lex_unget_unsave) can turn it
+     * into a clean json_error_out_of_memory instead of letting the
+     * lexer continue with a silently truncated saved_text. */
+    if (strbuffer_append_byte(&lex->saved_text, c))
+        lex->saved_text_oom = 1;
+}
 
 static int lex_get_save(lex_t *lex, json_error_t *error) {
     int c = stream_get(&lex->stream, error);
     if (c != STREAM_STATE_EOF && c != STREAM_STATE_ERROR)
         lex_save(lex, c);
+    if (lex->saved_text_oom) {
+        error_set(error, lex, json_error_out_of_memory,
+                  "out of memory while saving lexer token");
+        return STREAM_STATE_ERROR;
+    }
     return c;
 }
 
@@ -248,6 +269,15 @@ static void lex_unget_unsave(lex_t *lex, int c) {
         char d;
 #endif
         stream_unget(&lex->stream, c);
+        if (lex->saved_text_oom) {
+            /* saved_text was truncated by an earlier OOM, so the byte
+             * we would pop is no longer guaranteed to be at the buffer
+             * tail. Skip the pop to avoid silently corrupting
+             * saved_text. The OOM is already latched and the next
+             * lex_get_save() will turn it into a clean
+             * json_error_out_of_memory. */
+            return;
+        }
 #ifndef NDEBUG
         d =
 #endif
@@ -257,6 +287,12 @@ static void lex_unget_unsave(lex_t *lex, int c) {
 }
 
 static void lex_save_cached(lex_t *lex) {
+    /* Note: this is only called from the TOKEN_INVALID branch of
+     * lex_scan(), so a strbuffer_append_byte() failure here cannot
+     * change the outcome (the token is already invalid). lex_save()
+     * still records the failure on lex->saved_text_oom so that any
+     * caller inspecting saved_text downstream can turn it into a
+     * clean out-of-memory error if it cares. */
     while (lex->stream.buffer[lex->stream.buffer_pos] != '\0') {
         lex_save(lex, lex->stream.buffer[lex->stream.buffer_pos]);
         lex->stream.buffer_pos++;
@@ -584,6 +620,12 @@ static int lex_scan(lex_t *lex, json_error_t *error) {
     }
 
     lex_save(lex, c);
+    if (lex->saved_text_oom) {
+        error_set(error, lex, json_error_out_of_memory,
+                  "out of memory while saving lexer token");
+        lex->token = TOKEN_INVALID;
+        goto out;
+    }
 
     if (c == '{' || c == '}' || c == '[' || c == ']' || c == ':' || c == ',')
         lex->token = c;
@@ -646,6 +688,7 @@ static int lex_init(lex_t *lex, get_func get, size_t flags, void *data) {
 
     lex->flags = flags;
     lex->token = TOKEN_INVALID;
+    lex->saved_text_oom = 0;
     return 0;
 }
 


### PR DESCRIPTION
## Summary

`lex_save()` in `src/load.c` (line 230) calls `strbuffer_append_byte()` and discards its return value because `lex_save()` is itself `void`. `strbuffer_append_byte()` returns `-1` on allocation failure, so on memory exhaustion the lexer continues forward with a silently truncated `saved_text`.

This PR records the failure on the `lex_t` and lets the save-aware steps (`lex_get_save`, the `lex_scan()` dispatch immediately after the first `lex_save()`, and `lex_unget_unsave()`) translate it into a clean `json_error_out_of_memory` instead of letting the lexer continue with corrupted state.

The change is **intentionally minimal** — `lex_save()` keeps its `void` signature so the existing direct call sites in `lex_scan()` and `lex_scan_number()` compile unchanged. A more invasive direct-propagation alternative is discussed below; happy to switch to that direction in a follow-up if maintainers prefer.

> **Update (post-submission):** an external reviewer pointed out that the original patch only checked `saved_text_oom` inside `lex_get_save()`, so two paths still silently dropped the OOM: (1) the first `lex_save(lex, c)` in `lex_scan()` followed by single-character token dispatch, and (2) `lex_unget_unsave()` calling `strbuffer_pop()` on a tail that may have been truncated. The patch in this PR has been amended (force-pushed) to cover those two paths as well. The commit hash and the diff below reflect the amended commit.

---

## Reproduction

I observed this empirically with the standard `json_set_alloc_funcs2()` API (failing allocator that succeeds for the first N allocations and then returns NULL).

Test input: a small JSON document containing a long string array, e.g.

```c
const char *json_text =
    "[\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
    "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCC\"]";
```

With `fail_after=N` chosen so that the strbuffer growth allocation fails partway through scanning the string:

| `fail_after` | `json_loads()` | `error.text` |
|---|---|---|
| 3 (mid-scan) | NULL | `invalid token near '"AAAAAAAAAAAAAA'` ← only 14 bytes of the 96-byte input made it into `saved_text`, then the lexer kept going and the truncated prefix surfaced in the diagnostic. |
| 8–15 (later) | non-NULL root | empty `error.text` ← the lexer finished without noticing the truncation; the returned `json_t *` is a partially-corrupted parse of the input. |

The misleading `"invalid token near 'AAAAA...'"` message is itself a clear sign of the silent failure: the truncation is what produced it, not actual invalid input.

I did **not** reproduce a sanitiser-visible read past the end of `saved_text` under ASan/UBSan in the timing windows I tried (a hypothesis floated during external review was that `lex_scan_string()` might walk past the truncated buffer looking for the closing `"`, but I couldn't trigger that with my mock allocator). I'm reporting only what I could actually demonstrate: silent truncation and the resulting silent corruption.

---

## Severity

I'd characterise this as **medium**:

- Direct attacker-controlled triggering of the host's allocation failure is generally not realistic.
- It is, however, reachable on memory-constrained deployments (cgroup / container caps, embedded, custom allocators) processing untrusted JSON, and the user-visible behaviour is wrong (silent corruption / misleading error text) rather than a clean `json_error_out_of_memory`.

I previously assumed this might be high-severity (memory-safety class) but downgraded after ASan/UBSan failed to confirm an OOB read in my reproduction. Reporting honestly.

---

## Prior art (this finding is distinct)

Searched the `akheron/jansson` repository before opening this PR:

| Query | Open / Closed PR/issue |
|---|---|
| `lex_save` | 0 / 0 |
| `out of memory` | nothing relevant to this code path |
| `OOM propagation` | 0 / 0 |
| `silent corruption` | 0 / 0 |
| `strbuffer` | nothing on `lex_save()`'s `void` return |

I did not find an existing PR or issue covering this specific path. Apologies if I missed something.

---

## Patch (this commit)

```diff
--- a/src/load.c
+++ b/src/load.c
@@ -68,6 +68,13 @@
     size_t flags;
     size_t depth;
     int token;
+    /* Set when strbuffer_append_byte() fails inside lex_save(). The
+     * lexer continues forward (lex_save() is void-returning so the
+     * existing call sites cannot react), so we record the failure here
+     * and have the next lex_get_save() / lex_save_cached() turn it into
+     * a clean json_error_out_of_memory rather than a silently corrupt
+     * saved_text. */
+    int saved_text_oom;
     union {
         struct {
             char *val;
@@ -227,12 +234,26 @@
     return stream_get(&lex->stream, error);
 }

-static void lex_save(lex_t *lex, int c) { strbuffer_append_byte(&lex->saved_text, c); }
+static void lex_save(lex_t *lex, int c) {
+    /* strbuffer_append_byte() returns -1 on allocation failure but
+     * lex_save() is void to keep the existing call sites simple. We
+     * record the failure on the lex_t so the next save-aware step
+     * (lex_get_save / lex_save_cached / lex_unget_unsave) can turn it
+     * into a clean json_error_out_of_memory instead of letting the
+     * lexer continue with a silently truncated saved_text. */
+    if (strbuffer_append_byte(&lex->saved_text, c))
+        lex->saved_text_oom = 1;
+}

 static int lex_get_save(lex_t *lex, json_error_t *error) {
     int c = stream_get(&lex->stream, error);
     if (c != STREAM_STATE_EOF && c != STREAM_STATE_ERROR)
         lex_save(lex, c);
+    if (lex->saved_text_oom) {
+        error_set(error, lex, json_error_out_of_memory,
+                  "out of memory while saving lexer token");
+        return STREAM_STATE_ERROR;
+    }
     return c;
 }

@@ -248,6 +269,15 @@
         char d;
 #endif
         stream_unget(&lex->stream, c);
+        if (lex->saved_text_oom) {
+            /* saved_text was truncated by an earlier OOM, so the byte
+             * we would pop is no longer guaranteed to be at the buffer
+             * tail. Skip the pop to avoid silently corrupting
+             * saved_text. The OOM is already latched and the next
+             * lex_get_save() will turn it into a clean
+             * json_error_out_of_memory. */
+            return;
+        }
 #ifndef NDEBUG
         d =
 #endif
@@ -257,6 +287,12 @@
 }

 static void lex_save_cached(lex_t *lex) {
+    /* Note: this is only called from the TOKEN_INVALID branch of
+     * lex_scan(), so a strbuffer_append_byte() failure here cannot
+     * change the outcome (the token is already invalid). lex_save()
+     * still records the failure on lex->saved_text_oom so that any
+     * caller inspecting saved_text downstream can turn it into a
+     * clean out-of-memory error if it cares. */
     while (lex->stream.buffer[lex->stream.buffer_pos] != '\0') {
         lex_save(lex, lex->stream.buffer[lex->stream.buffer_pos]);
         lex->stream.buffer_pos++;
@@ -584,6 +620,12 @@
     }

     lex_save(lex, c);
+    if (lex->saved_text_oom) {
+        error_set(error, lex, json_error_out_of_memory,
+                  "out of memory while saving lexer token");
+        lex->token = TOKEN_INVALID;
+        goto out;
+    }

     if (c == '{' || c == '}' || c == '[' || c == ']' || c == ':' || c == ',')
         lex->token = c;
@@ -646,6 +688,7 @@
     lex->flags = flags;
     lex->token = TOKEN_INVALID;
+    lex->saved_text_oom = 0;
     return 0;
 }
```

### Change summary

| Change | Effect |
|---|---|
| New `int saved_text_oom` field in `lex_t` | Records `strbuffer_append_byte()` failure when `lex_save()` cannot propagate it directly. 4-byte struct growth, ABI is internal. |
| `lex_save()` records failure on the new field | Was already silently dropping the return value; now the failure is preserved. |
| `lex_get_save()` checks the field and returns `STREAM_STATE_ERROR + json_error_out_of_memory` | Catches the OOM on the main token-scanning loop. |
| `lex_unget_unsave()` skips `strbuffer_pop()` when the field is set | Avoids popping a byte that is no longer guaranteed to be at the buffer tail, which under `NDEBUG` (when the existing `assert(c == d)` is stripped) would otherwise quietly desynchronise `saved_text`. |
| `lex_scan()` checks the field immediately after the first `lex_save(lex, c)` | Catches OOM on the single-character-token dispatch path (`{ } [ ] : ,`) at the source, instead of relying on whatever the caller does with `saved_text` next. |
| `lex_save_cached()` documented; no behaviour change | Only reachable from the `TOKEN_INVALID` branch, so propagation is unnecessary. |
| `lex_init()` initialises the field to 0 | Standard housekeeping. |

Together these reduce the silent-corruption window in the main token-scanning paths I could identify. I'm not claiming every conceivable caller is covered — `lex_save_cached()`'s comment above and the alternative direction below describe the rest. Reasonable callers should still honour the error return on the public API.

The existing direct `lex_save()` call sites (`lex_scan_number` line 554, `lex_scan` line 613, in the amended commit) compile unchanged and reach the OOM check on the next `lex_get_save()` / `lex_unget_unsave()` call, or — for the single-character-token dispatch path — on the immediate post-`lex_save()` check just added in `lex_scan()` itself.

---

## Alternative (more invasive) direction

A reviewer might reasonably prefer changing `lex_save()` to return `int` and threading the error through every call site. That is closer to how the rest of `load.c`'s error handling works and avoids the "side-channel via lex_t field" feel of this patch.

The cost is touching ~5 call sites (lines 235, 261, 527, 586, 623) and changing `lex_save_cached()`'s signature to take `json_error_t *error` and return `int`. I'd be happy to follow up with that variant if maintainers prefer it; I just didn't want to bundle that scope into the first PR.

---

## Test plan

A standalone reproducer with `json_set_alloc_funcs2()` and a counted-fail allocator is available on request:

| Case | Input | Before patch | After patch |
|---|---|---|---|
| Normal | small valid JSON | OK | OK |
| `fail_after=3` (mid-string scan) | long string array | NULL root + misleading `invalid token near "AAAA...` (truncated prefix) | NULL root + `json_error_out_of_memory: out of memory while saving lexer token` |
| `fail_after=8..15` (late) | long string array | non-NULL root with silently corrupted parse | NULL root + clean OOM error |
| Normal small inputs | various | OK | OK (no change) |

I built jansson with `-fsanitize=address,undefined` and ran the reproducer; no sanitizer reports were produced before or after the patch (so the silent-corruption window is not, at least in my reproduction, also a memory-safety bug — only a correctness / error-reporting bug).

A `json_set_alloc_funcs2`-based test could plausibly fit into `test/suites/api/`; happy to add one if you'd like it in this PR or as a follow-up.

### Checklist

- [x] Patch is minimal (1 file, ~44 net lines including comments, after the post-submission amend covering `lex_unget_unsave()` and the `lex_scan()` dispatch path).
- [x] No public API or ABI change (the new field is internal to `load.c`).
- [x] Existing direct `lex_save()` call sites compile unchanged.
- [x] `lex_init()` initialises the new field.
- [x] Reproduction is via the public `json_set_alloc_funcs2()` API.
- [ ] Integrated test in `test/suites/api/` — happy to add on request.

---

## Disclosure note

This is a public report (uncoordinated). Opening a public PR is, by definition, public disclosure — describing it as a "coordinated" 90-day window was wrong on my part. Whatever risk this PR contains was already on the public record the moment I opened it. Apologies for the wrong terminology.

---

## Reporter

Tae-Eun Song (higheun@gmail.com)

Tooling: code review pipeline running both Claude Code CLI and an external `gpt-5.3-codex` CLI as independent reviewers, plus a small mock-allocator reproducer harness. Findings are cross-checked against the actual code before submission.

Thanks for jansson — it's been a pleasure to read. Happy to revise the patch direction (the "invasive" variant above, an integrated test, or anything else) on request.
