### PR TITLE
configure: only use --default-symver when the linker supports it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,7 +135,16 @@ AC_SUBST(JSON_BSYMBOLIC_LDFLAGS)
 
 # Enable symbol versioning on GNU libc
 JSON_SYMVER_LDFLAGS=
-AC_CHECK_DECL([__GLIBC__], [JSON_SYMVER_LDFLAGS=-Wl,--default-symver])
+AC_CHECK_DECL([__GLIBC__], [
+    saved_LDFLAGS="$LDFLAGS"
+    LDFLAGS="$LDFLAGS -Wl,--default-symver"
+    AC_MSG_CHECKING([whether the linker accepts -Wl,--default-symver])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
+        [AC_MSG_RESULT([yes])
+         JSON_SYMVER_LDFLAGS=-Wl,--default-symver],
+        [AC_MSG_RESULT([no])])
+    LDFLAGS="$saved_LDFLAGS"
+])
 AC_SUBST([JSON_SYMVER_LDFLAGS])
 
 AC_ARG_ENABLE([dtoa],


### PR DESCRIPTION
jansson enables symbol versioning on glibc by passing -Wl,--default-symver to the linker. This is a GNU ld option which is not understood by every linker, e.g. ld.lld errors out with:

  ld.lld: error: unknown argument '--default-symver'

Probe the linker with a link test before adding the flag so the build works with both GNU ld and lld. When the linker does not accept the option the symbol versioning provided by the explicit version script is still applied; only the implicit default version is dropped.